### PR TITLE
fix: handle tracker entity defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
 2. Włącz „Śledź urządzenia” i wybierz trackery.
 3. Opcjonalnie: nadpisz nazwę obszaru, używaj nazw urządzeń.
 
+*Options flow jest dwukrokowy: najpierw wybór trybu (Static/Tracker), potem odpowiednie pola.*
+
 ### 🔹 Opcje zaawansowane
 - **Interwał aktualizacji** – domyślnie 30 min.
 - **Zmienne godzinowe/dzienne** – wybierz, które dane pobierać.
@@ -76,6 +78,7 @@ openmeteo:
   hourly_variables:
     - temperature_2m
     - relative_humidity_2m
+    - dewpoint_2m
     - precipitation
     - weathercode
   daily_variables:

--- a/custom_components/openmeteo/config_flow.py
+++ b/custom_components/openmeteo/config_flow.py
@@ -33,7 +33,7 @@ def _build_schema(hass: HomeAssistant, mode: str, defaults: dict[str, Any]) -> v
     if mode == MODE_TRACK:
         data: dict[Any, Any] = {
             vol.Required(
-                CONF_ENTITY_ID, default=defaults.get(CONF_ENTITY_ID, "")
+                CONF_ENTITY_ID, default=defaults.get(CONF_ENTITY_ID, None)
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["device_tracker", "person"])
             ),
@@ -208,7 +208,7 @@ class OpenMeteoOptionsFlow(config_entries.OptionsFlow):
                     vol.Required(
                         CONF_ENTITY_ID,
 
-                        default=defaults.get(CONF_ENTITY_ID, ""),
+                        default=defaults.get(CONF_ENTITY_ID, None),
                     ): selector.EntitySelector(
                         selector.EntitySelectorConfig(
                             domain=["device_tracker", "person"]

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"


### PR DESCRIPTION
## Summary
- avoid empty string defaults for tracker entity in config/options flow
- document two-step options flow and add dewpoint_2m example
- bump integration version to 1.3.9

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8ca1e4698832d8040a7920ab92637