### PR TITLE
Fix UV index sensor in Open-Meteo integration

### DIFF
--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -234,6 +234,7 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "cloud_cover",
                 "precipitation",
                 "visibility",
+                "uv_index",
             ]
         )
 

--- a/custom_components/openmeteo/sensor.py
+++ b/custom_components/openmeteo/sensor.py
@@ -80,7 +80,8 @@ SENSOR_TYPES: dict[str, dict] = {
         "unit": "UV Index",
         "icon": "mdi:sun-wireless-outline",
         "device_class": None,
-        "value_fn": lambda d: _first_hourly(d, "uv_index"),
+        "value_fn": lambda d: d.get("current", {}).get("uv_index")
+        or _first_hourly(d, "uv_index"),
     },
     "precipitation_probability": {
         "name": "Prawdopodobieństwo opadów",


### PR DESCRIPTION
## Summary
- Request UV index in current weather data
- Read UV index from current API response

## Testing
- `python -m compileall custom_components/openmeteo`


------
https://chatgpt.com/codex/tasks/task_e_68a9759290d0832d94bc03e8e55a2d1b