### PR TITLE
Add daily UV request and fallback for UV sensor

### DIFF
--- a/custom_components/openmeteo/const.py
+++ b/custom_components/openmeteo/const.py
@@ -69,6 +69,8 @@ DEFAULT_DAILY_VARIABLES = [
     "wind_direction_10m_dominant",
     "sunrise",
     "sunset",
+    "uv_index_max",
+    "uv_index_clear_sky_max",
 ]
 
 DEFAULT_HOURLY_VARIABLES = [

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"

--- a/custom_components/openmeteo/sensor.py
+++ b/custom_components/openmeteo/sensor.py
@@ -80,8 +80,10 @@ SENSOR_TYPES: dict[str, dict] = {
         "unit": "UV Index",
         "icon": "mdi:sun-wireless-outline",
         "device_class": None,
-        "value_fn": lambda d: d.get("current", {}).get("uv_index")
-        or _first_hourly(d, "uv_index"),
+        "value_fn": lambda d: (d.get("current", {}) or {}).get("uv_index")
+        or _first_hourly(d, "uv_index")
+        or (d.get("daily", {}).get("uv_index_max", [None])[0])
+        or 0,
     },
     "precipitation_probability": {
         "name": "Prawdopodobieństwo opadów",


### PR DESCRIPTION
## Summary
- request daily uv values and bump manifest version
- fall back to hourly or daily max for uv index sensor

## Testing
- `python -m py_compile custom_components/openmeteo/const.py custom_components/openmeteo/sensor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a978f47c2c832d99e9c1234198a27c