### PR TITLE
Subscribe to tracked entity state

### DIFF
--- a/custom_components/openmeteo/__init__.py
+++ b/custom_components/openmeteo/__init__.py
@@ -30,6 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Open-Meteo from a config entry."""
     coordinator = OpenMeteoDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
+    await coordinator._resubscribe_tracked_entity(entry.options.get("entity_id"))
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coordinator}
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_options_update_listener))

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"


### PR DESCRIPTION
## Summary
- subscribe to tracked entity state and refresh when coordinates change
- resubscribe coordinator after options update or initial setup
- bump integration version to 1.3.14

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a97de8eb7c832d9d4fda4a67b82ced