### PR TITLE
Fix entity tracking callback

### DIFF
--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"


### PR DESCRIPTION
## Summary
- Replace deprecated `async_track_state_change` with `async_track_state_change_event`
- Await coordinator refresh directly in async entity tracking callback
- Bump integration version to 1.3.15

## Testing
- `pytest`
- `python -m py_compile custom_components/openmeteo/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a97f71d53c832d820b8f46d60e8a8a