### PR TITLE
Fix option defaults and track entity resolution

### DIFF
--- a/custom_components/openmeteo/config_flow.py
+++ b/custom_components/openmeteo/config_flow.py
@@ -147,11 +147,11 @@ class OpenMeteoOptionsFlow(config_entries.OptionsFlow):
         self._entry = entry
         # Copy options so we can safely mutate defaults
         self._options: dict[str, Any] = dict(entry.options)
+        eff = {**entry.data, **entry.options}
         # Migrate old configs that stored an empty string for the entity
         if self._options.get(CONF_ENTITY_ID) == "":
             self._options[CONF_ENTITY_ID] = None
-        # Default mode comes only from saved options
-        self._mode = self._options.get(CONF_MODE, MODE_STATIC)
+        self._mode = eff.get(CONF_MODE, MODE_STATIC)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -113,8 +113,9 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Return (lat, lon, from_entity) chosen by precedence."""
         entry = self.config_entry
         opts = entry.options or {}
-        track_enabled = bool(
-            opts.get("track", opts.get("track_enabled", False))
+        track_enabled = (
+            opts.get("track")
+            or opts.get("track_enabled")
             or (entry.options.get(CONF_MODE) or entry.data.get(CONF_MODE)) == MODE_TRACK
         )
         track_entity_id = (
@@ -122,6 +123,10 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             or opts.get("track_entity")
             or opts.get(CONF_ENTITY_ID)
             or opts.get(CONF_TRACKED_ENTITY_ID)
+            or entry.data.get("track_entity_id")
+            or entry.data.get("track_entity")
+            or entry.data.get(CONF_ENTITY_ID)
+            or entry.data.get(CONF_TRACKED_ENTITY_ID)
         )
         lat = opts.get(CONF_LATITUDE, entry.data.get(CONF_LATITUDE))
         lon = opts.get(CONF_LONGITUDE, entry.data.get(CONF_LONGITUDE))

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"


### PR DESCRIPTION
## Summary
- Consider both config entry data and options for TRACK mode & tracked entity
- Persist mode in options and prefill options form with effective values
- Bump version to 1.3.16

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a981d03330832d81648c8a79e3bb51