### PR TITLE
feat: simplify UV index handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌤 Open-Meteo – Integracja dla Home Assistant (v1.3.9)
+# 🌤 Open-Meteo – Integracja dla Home Assistant (v1.3.19)
 
 [Open-Meteo](https://open-meteo.com/) — darmowe, szybkie API pogody **bez klucza API**.  
 Integracja dostarcza encję `weather` z bieżącą pogodą i prognozą oraz zestaw sensorów do automatyzacji.
@@ -12,7 +12,7 @@ Integracja dostarcza encję `weather` z bieżącą pogodą i prognozą oraz zest
   - **Static** — stałe współrzędne,
   - **Tracker** — z encji `device_tracker` / `person` (GPS) z **automatycznym fallbackiem**.
 - **Punkt rosy** z API: `dewpoint_2m` (bez lokalnych obliczeń).
-- **Sensory pomocnicze** (łatwe do automatyzacji): temperatura, wilgotność, ciśnienie, wiatr (prędkość / porywy / kierunek), widzialność, UV, opady i ich prawdopodobieństwo.
+- **Sensory pomocnicze** (łatwe do automatyzacji): temperatura, wilgotność, ciśnienie, wiatr (prędkość / porywy / kierunek), widzialność, Indeks UV (godzinowy), opady i ich prawdopodobieństwo.
 
 ---
 
@@ -192,6 +192,9 @@ cards:
 ---
 
 ## 🗒️ Changelog
+
+### 1.3.19
+- Uproszczono obsługę UV – pozostaje tylko jeden sensor godzinowy.
 
 ### 1.3.9
 - **Punkt rosy** z API (`dewpoint_2m`) — usunięto lokalne liczenie.

--- a/custom_components/openmeteo/const.py
+++ b/custom_components/openmeteo/const.py
@@ -40,8 +40,7 @@ CONF_UNITS = "units"
 CONF_API_PROVIDER = "api_provider"
 CONF_API_KEY = "api_key"
 CONF_AREA_NAME_OVERRIDE = "area_name_override"
-CONF_UV_INDEX_HOURLY = "uv_index_hourly"
-CONF_UV_INDEX_MAX = "uv_index_max_daily"
+CONF_UV_INDEX = "uv_index"
 
 # Modes
 MODE_STATIC = "static"
@@ -71,8 +70,6 @@ DEFAULT_DAILY_VARIABLES = [
     "wind_direction_10m_dominant",
     "sunrise",
     "sunset",
-    "uv_index_max",
-    "uv_index_clear_sky_max",
 ]
 
 DEFAULT_HOURLY_VARIABLES = [

--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -173,7 +173,7 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             loc_name = self.location_name
 
         hourly_vars = list(dict.fromkeys(DEFAULT_HOURLY_VARIABLES + ["uv_index"]))
-        daily_vars = list(dict.fromkeys(DEFAULT_DAILY_VARIABLES + ["uv_index_max"]))
+        daily_vars = DEFAULT_DAILY_VARIABLES
         params = {
             "latitude": latitude,
             "longitude": longitude,
@@ -234,9 +234,6 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hourly = self._last_data.setdefault("hourly", {})
             hourly.setdefault("time", [])
             hourly.setdefault("uv_index", [])
-            daily = self._last_data.setdefault("daily", {})
-            daily.setdefault("time", [])
-            daily.setdefault("uv_index_max", [])
             if from_entity:
                 self._last_coords = (latitude, longitude)
             return self._last_data

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"

--- a/custom_components/openmeteo/translations/en.json
+++ b/custom_components/openmeteo/translations/en.json
@@ -47,6 +47,5 @@
       "invalid_entity": "Entity has no GPS coordinates"
     }
   },
-  "uv_index_hourly": { "name": "UV Index (hourly)" },
-  "uv_index_max_daily": { "name": "UV Index (max today)" }
+  "uv_index": { "name": "UV Index" }
 }

--- a/custom_components/openmeteo/translations/pl.json
+++ b/custom_components/openmeteo/translations/pl.json
@@ -47,6 +47,5 @@
       "invalid_entity": "Encja nie ma współrzędnych GPS"
     }
   },
-  "uv_index_hourly": { "name": "Indeks UV (godzinowy)" },
-  "uv_index_max_daily": { "name": "Indeks UV (max dziś)" }
+  "uv_index": { "name": "Indeks UV" }
 }


### PR DESCRIPTION
## Summary
- simplify UV index API usage and data handling
- drop daily UV max sensor in favour of single hourly UV index entity
- update translations and documentation; bump version to 1.3.19

## Testing
- `python -m py_compile custom_components/openmeteo/coordinator.py custom_components/openmeteo/sensor.py custom_components/openmeteo/const.py`
- `python -m json.tool custom_components/openmeteo/translations/pl.json >/dev/null`
- `python -m json.tool custom_components/openmeteo/translations/en.json >/dev/null`
- `python -m json.tool custom_components/openmeteo/manifest.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68a9e73fa798832d989a63413341572a