### PR TITLE
fix: clean up timers and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@
 - fix: dynamically refresh entry title when coords change
 
 ## 1.3.23
-- fix(cleanup): unregister timers/subscriptions on unload to avoid lingering timer in tests; keep dynamic title refresh
+- fix(tests): use async_update_entry for options in tests; unload entries
+- fix(cleanup): track and unsubscribe timers/subscriptions on unload to avoid lingering timers


### PR DESCRIPTION
## Summary
- track all unsubscribe callbacks and clear them on unload
- stop lingering timers and update config entry options in tests
- document cleanup and testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac93aec880832dae5f8c32445ed548