### PR TITLE
feat: show place-centric names for Open-Meteo entities

### DIFF
--- a/custom_components/openmeteo/config_flow.py
+++ b/custom_components/openmeteo/config_flow.py
@@ -27,6 +27,8 @@ from .const import (
     MODE_TRACK,
     CONF_API_PROVIDER,
     DEFAULT_API_PROVIDER,
+    CONF_USE_PLACE_AS_DEVICE_NAME,
+    DEFAULT_USE_PLACE_AS_DEVICE_NAME,
 )
 
 
@@ -71,6 +73,13 @@ def _build_schema(hass: HomeAssistant, mode: str, defaults: dict[str, Any]) -> v
                 CONF_API_PROVIDER,
                 default=defaults.get(CONF_API_PROVIDER, DEFAULT_API_PROVIDER),
             ): vol.In(["open_meteo"]),
+            vol.Required(
+                CONF_USE_PLACE_AS_DEVICE_NAME,
+                default=defaults.get(
+                    CONF_USE_PLACE_AS_DEVICE_NAME,
+                    DEFAULT_USE_PLACE_AS_DEVICE_NAME,
+                ),
+            ): bool,
             vol.Optional(
                 CONF_AREA_NAME_OVERRIDE,
                 default=defaults.get(CONF_AREA_NAME_OVERRIDE, ""),

--- a/custom_components/openmeteo/const.py
+++ b/custom_components/openmeteo/const.py
@@ -41,6 +41,7 @@ CONF_API_PROVIDER = "api_provider"
 CONF_API_KEY = "api_key"
 CONF_AREA_NAME_OVERRIDE = "area_name_override"
 CONF_UV_INDEX = "uv_index"
+CONF_USE_PLACE_AS_DEVICE_NAME = "use_place_as_device_name"
 
 # Modes
 MODE_STATIC = "static"
@@ -60,6 +61,7 @@ DEFAULT_UPDATE_INTERVAL = DEFAULT_SCAN_INTERVAL
 DEFAULT_MIN_TRACK_INTERVAL = 15  # minutes
 DEFAULT_UNITS = "metric"
 DEFAULT_API_PROVIDER = "open_meteo"
+DEFAULT_USE_PLACE_AS_DEVICE_NAME = True
 
 DEFAULT_DAILY_VARIABLES = [
     "temperature_2m_max",

--- a/custom_components/openmeteo/sensor.py
+++ b/custom_components/openmeteo/sensor.py
@@ -3,7 +3,14 @@
 """Sensor platform for Open-Meteo."""
 from __future__ import annotations
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from dataclasses import dataclass
+from typing import Callable
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEGREE,
@@ -15,12 +22,20 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 from homeassistant.util import dt as dt_util
 
 from .coordinator import OpenMeteoDataUpdateCoordinator
-from .const import DOMAIN, ATTRIBUTION
+from .const import (
+    DOMAIN,
+    ATTRIBUTION,
+    CONF_USE_PLACE_AS_DEVICE_NAME,
+    DEFAULT_USE_PLACE_AS_DEVICE_NAME,
+)
+from .weather import get_place_title
 
 
 
@@ -65,114 +80,132 @@ def _extra_attrs(data: dict) -> dict:
     }
 
 
-SENSOR_TYPES: dict[str, dict] = {
-    "temperature": {
-        "name": "Temperatura",
-        "unit": UnitOfTemperature.CELSIUS,
-        "icon": "mdi:thermometer",
-        "device_class": "temperature",
-        "value_fn": lambda d: d.get("current_weather", {}).get("temperature"),
-    },
-    "humidity": {
-        "name": "Wilgotność",
-        "unit": PERCENTAGE,
-        "icon": "mdi:water-percent",
-        "device_class": "humidity",
-        "value_fn": lambda d: _first_hourly(d, "relative_humidity_2m"),
-    },
-    "apparent_temperature": {
-        "name": "Temperatura odczuwalna",
-        "unit": UnitOfTemperature.CELSIUS,
-        "icon": "mdi:thermometer-alert",
-        "device_class": "temperature",
-        "value_fn": lambda d: _first_hourly(d, "apparent_temperature"),
-    },
-    "precipitation_probability": {
-        "name": "Prawdopodobieństwo opadów",
-        "unit": PERCENTAGE,
-        "icon": "mdi:weather-pouring",
-        "device_class": None,
-        "value_fn": lambda d: _first_hourly(d, "precipitation_probability"),
-    },
-    "precipitation_total": {
-        "name": "Suma opadów (deszcz+śnieg)",
-        "unit": UnitOfPrecipitationDepth.MILLIMETERS,
-        "icon": "mdi:cup-water",
-        "device_class": "precipitation",
-        # spójnie z _first_hourly
-        "value_fn": lambda d: (_first_hourly(d, "precipitation") or 0)
-                              + (_first_hourly(d, "snowfall") or 0),
-    },
-    "wind_speed": {
-        "name": "Prędkość wiatru",
-        "unit": UnitOfSpeed.KILOMETERS_PER_HOUR,
-        "icon": "mdi:weather-windy",
-        "device_class": None,
-        "value_fn": lambda d: d.get("current_weather", {}).get("windspeed"),
-    },
-    "wind_gust": {
-        "name": "Porywy wiatru",
-        "unit": UnitOfSpeed.KILOMETERS_PER_HOUR,
-        "icon": "mdi:weather-windy-variant",
-        "device_class": None,
-        "value_fn": lambda d: _first_hourly(d, "wind_gusts_10m"),
-    },
-    "wind_bearing": {
-        "name": "Kierunek wiatru",
-        "unit": DEGREE,
-        "icon": "mdi:compass",
-        "device_class": None,
-        "value_fn": lambda d: d.get("current_weather", {}).get("winddirection"),
-    },
-    "pressure": {
-        "name": "Ciśnienie",
-        "unit": UnitOfPressure.HPA,
-        "icon": "mdi:gauge",
-        "device_class": "pressure",
-        "value_fn": lambda d: _first_hourly(d, "pressure_msl"),
-    },
-    "visibility": {
-        "name": "Widzialność",
-        "unit": UnitOfLength.KILOMETERS,
-        "icon": "mdi:eye",
-        "device_class": None,
-        "value_fn": _visibility_km,
-    },
-    "dew_point": {
-        "name": "Punkt rosy",
-        "unit": UnitOfTemperature.CELSIUS,
-        "icon": "mdi:water",
-        "device_class": "temperature",
-        "value_fn": lambda d: d.get("current", {}).get("dewpoint_2m")
+@dataclass
+class OpenMeteoSensorDescription(SensorEntityDescription):
+    value_fn: Callable[[dict], Any]
+
+
+SENSOR_TYPES: dict[str, OpenMeteoSensorDescription] = {
+    "temperature": OpenMeteoSensorDescription(
+        key="temperature",
+        name="Temperatura",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer",
+        device_class="temperature",
+        value_fn=lambda d: d.get("current_weather", {}).get("temperature"),
+    ),
+    "humidity": OpenMeteoSensorDescription(
+        key="humidity",
+        name="Wilgotność",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:water-percent",
+        device_class="humidity",
+        value_fn=lambda d: _first_hourly(d, "relative_humidity_2m"),
+    ),
+    "apparent_temperature": OpenMeteoSensorDescription(
+        key="apparent_temperature",
+        name="Temperatura odczuwalna",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-alert",
+        device_class="temperature",
+        value_fn=lambda d: _first_hourly(d, "apparent_temperature"),
+    ),
+    "precipitation_probability": OpenMeteoSensorDescription(
+        key="precipitation_probability",
+        name="Prawdopodobieństwo opadów",
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:weather-pouring",
+        device_class=None,
+        value_fn=lambda d: _first_hourly(d, "precipitation_probability"),
+    ),
+    "precipitation_total": OpenMeteoSensorDescription(
+        key="precipitation_total",
+        name="Suma opadów",
+        native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
+        icon="mdi:cup-water",
+        device_class="precipitation",
+        value_fn=lambda d: (_first_hourly(d, "precipitation") or 0)
+        + (_first_hourly(d, "snowfall") or 0),
+    ),
+    "wind_speed": OpenMeteoSensorDescription(
+        key="wind_speed",
+        name="Prędkość wiatru",
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        icon="mdi:weather-windy",
+        device_class=None,
+        value_fn=lambda d: d.get("current_weather", {}).get("windspeed"),
+    ),
+    "wind_gust": OpenMeteoSensorDescription(
+        key="wind_gust",
+        name="Porywy wiatru",
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        icon="mdi:weather-windy-variant",
+        device_class=None,
+        value_fn=lambda d: _first_hourly(d, "wind_gusts_10m"),
+    ),
+    "wind_bearing": OpenMeteoSensorDescription(
+        key="wind_bearing",
+        name="Kierunek wiatru",
+        native_unit_of_measurement=DEGREE,
+        icon="mdi:compass",
+        device_class=None,
+        value_fn=lambda d: d.get("current_weather", {}).get("winddirection"),
+    ),
+    "pressure": OpenMeteoSensorDescription(
+        key="pressure",
+        name="Ciśnienie",
+        native_unit_of_measurement=UnitOfPressure.HPA,
+        icon="mdi:gauge",
+        device_class="pressure",
+        value_fn=lambda d: _first_hourly(d, "pressure_msl"),
+    ),
+    "visibility": OpenMeteoSensorDescription(
+        key="visibility",
+        name="Widzialność",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        icon="mdi:eye",
+        device_class=None,
+        value_fn=_visibility_km,
+    ),
+    "dew_point": OpenMeteoSensorDescription(
+        key="dew_point",
+        name="Punkt rosy",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:water",
+        device_class="temperature",
+        value_fn=lambda d: d.get("current", {}).get("dewpoint_2m")
         or _first_hourly(d, "dewpoint_2m"),
-    },
-    "location": {
-        "name": "Lokalizacja",
-        "unit": None,
-        "icon": "mdi:map-marker",
-        "device_class": None,
-        "value_fn": lambda d: (
+    ),
+    "location": OpenMeteoSensorDescription(
+        key="location",
+        name="Lokalizacja",
+        native_unit_of_measurement=None,
+        icon="mdi:map-marker",
+        device_class=None,
+        value_fn=lambda d: (
             f"{d.get('location', {}).get('latitude')}, {d.get('location', {}).get('longitude')}"
             if d.get("location", {}).get("latitude") is not None
             and d.get("location", {}).get("longitude") is not None
             else None
         ),
-    },
-
-    "sunrise": {
-        "name": "Wschód słońca",
-        "unit": None,
-        "icon": "mdi:weather-sunset-up",
-        "device_class": "timestamp",
-        "value_fn": lambda d: _first_daily_dt(d, "sunrise"),
-    },
-    "sunset": {
-        "name": "Zachód słońca",
-        "unit": None,
-        "icon": "mdi:weather-sunset-down",
-        "device_class": "timestamp",
-        "value_fn": lambda d: _first_daily_dt(d, "sunset"),
-    },}
+    ),
+    "sunrise": OpenMeteoSensorDescription(
+        key="sunrise",
+        name="Wschód słońca",
+        native_unit_of_measurement=None,
+        icon="mdi:weather-sunset-up",
+        device_class="timestamp",
+        value_fn=lambda d: _first_daily_dt(d, "sunrise"),
+    ),
+    "sunset": OpenMeteoSensorDescription(
+        key="sunset",
+        name="Zachód słońca",
+        native_unit_of_measurement=None,
+        icon="mdi:weather-sunset-down",
+        device_class="timestamp",
+        value_fn=lambda d: _first_daily_dt(d, "sunset"),
+    ),
+}
 
 
 async def async_setup_entry(
@@ -198,32 +231,54 @@ class OpenMeteoSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._sensor_type = sensor_type
         self._config_entry = config_entry
-        self._attr_name = f"{config_entry.data.get('name', 'Open-Meteo')} {SENSOR_TYPES[sensor_type]['name']}"
+        self.entity_description = SENSOR_TYPES[sensor_type]
+        self._value_fn = self.entity_description.value_fn
+        data = {**config_entry.data, **config_entry.options}
+        self._use_place = data.get(
+            CONF_USE_PLACE_AS_DEVICE_NAME, DEFAULT_USE_PLACE_AS_DEVICE_NAME
+        )
+        if self._use_place:
+            self._attr_has_entity_name = True
+            self._attr_name = None
+            place_slug = slugify(get_place_title(coordinator.hass, config_entry))
+            if place_slug:
+                self._attr_suggested_object_id = f"{place_slug}_{sensor_type}"
+        else:
+            base = config_entry.data.get("name", "Open-Meteo")
+            self._attr_name = f"{base} {self.entity_description.name}"
         self._attr_unique_id = f"{config_entry.entry_id}-{sensor_type}"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, config_entry.entry_id)},
-            "name": "Open-Meteo",
-            "manufacturer": "Open-Meteo",
-        }
+        
+    @property
+    def device_info(self) -> DeviceInfo:
+        name = (
+            get_place_title(self.hass, self._config_entry)
+            if self._use_place
+            else "Open-Meteo"
+        )
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.entry_id)},
+            manufacturer="Open-Meteo",
+            name=name,
+        )
 
     @property
     def native_value(self):
         if not self.coordinator.data:
             return None
-        value = SENSOR_TYPES[self._sensor_type]["value_fn"](self.coordinator.data)
+        value = self._value_fn(self.coordinator.data)
         return round(value, 2) if isinstance(value, (int, float)) else value
 
     @property
     def native_unit_of_measurement(self):
-        return SENSOR_TYPES[self._sensor_type]["unit"]
+        return self.entity_description.native_unit_of_measurement
 
     @property
     def icon(self):
-        return SENSOR_TYPES[self._sensor_type]["icon"]
+        return self.entity_description.icon
 
     @property
     def device_class(self):
-        return SENSOR_TYPES[self._sensor_type]["device_class"]
+        return self.entity_description.device_class
 
     @property
     def available(self) -> bool:
@@ -254,6 +309,25 @@ class OpenMeteoSensor(CoordinatorEntity, SensorEntity):
             pass
         return attrs
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        store = (
+            self.hass.data.setdefault(DOMAIN, {})
+            .setdefault("entries", {})
+            .setdefault(self._config_entry.entry_id, {})
+        )
+        store.setdefault("entities", []).append(self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        store = (
+            self.hass.data.get(DOMAIN, {})
+            .get("entries", {})
+            .get(self._config_entry.entry_id)
+        )
+        if store and self in store.get("entities", []):
+            store["entities"].remove(self)
+        await super().async_will_remove_from_hass()
+
 
 class OpenMeteoUvIndexSensor(CoordinatorEntity, SensorEntity):
     """UV Index sensor for the current hour."""
@@ -264,18 +338,25 @@ class OpenMeteoUvIndexSensor(CoordinatorEntity, SensorEntity):
         config_entry: ConfigEntry,
     ) -> None:
         super().__init__(coordinator)
-        name = config_entry.data.get("name", "Open-Meteo")
         self._config_entry = config_entry
-        self._attr_name = f"{name} Indeks UV"
+        data = {**config_entry.data, **config_entry.options}
+        self._use_place = data.get(
+            CONF_USE_PLACE_AS_DEVICE_NAME, DEFAULT_USE_PLACE_AS_DEVICE_NAME
+        )
         self._attr_unique_id = f"{config_entry.entry_id}-uv_index"
         self._attr_native_unit_of_measurement = "UV Index"
         self._attr_icon = "mdi:weather-sunny-alert"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, config_entry.entry_id)},
-            "name": "Open-Meteo",
-            "manufacturer": "Open-Meteo",
-        }
+        if self._use_place:
+            self._attr_has_entity_name = True
+            self._attr_name = None
+            self._attr_translation_key = "uv_index"
+            place_slug = slugify(get_place_title(coordinator.hass, config_entry))
+            if place_slug:
+                self._attr_suggested_object_id = f"{place_slug}_uv_index"
+        else:
+            base = config_entry.data.get("name", "Open-Meteo")
+            self._attr_name = f"{base} Indeks UV"
 
     @property
     def native_value(self):
@@ -322,3 +403,35 @@ class OpenMeteoUvIndexSensor(CoordinatorEntity, SensorEntity):
         except Exception:
             pass
         return attrs
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        name = (
+            get_place_title(self.hass, self._config_entry)
+            if self._use_place
+            else "Open-Meteo"
+        )
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.entry_id)},
+            manufacturer="Open-Meteo",
+            name=name,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        store = (
+            self.hass.data.setdefault(DOMAIN, {})
+            .setdefault("entries", {})
+            .setdefault(self._config_entry.entry_id, {})
+        )
+        store.setdefault("entities", []).append(self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        store = (
+            self.hass.data.get(DOMAIN, {})
+            .get("entries", {})
+            .get(self._config_entry.entry_id)
+        )
+        if store and self in store.get("entities", []):
+            store["entities"].remove(self)
+        await super().async_will_remove_from_hass()

--- a/custom_components/openmeteo/translations/en.json
+++ b/custom_components/openmeteo/translations/en.json
@@ -14,7 +14,8 @@
           "update_interval": "Update interval (s)",
           "units": "Units",
           "api_provider": "API provider",
-          "area_name_override": "Area name override"
+          "area_name_override": "Area name override",
+          "use_place_as_device_name": "Use place as device name"
         }
       }
     },
@@ -37,7 +38,8 @@
           "update_interval": "Update interval (s)",
           "units": "Units",
           "api_provider": "API provider",
-          "area_name_override": "Area name override"
+          "area_name_override": "Area name override",
+          "use_place_as_device_name": "Use place as device name"
         }
       }
     },

--- a/custom_components/openmeteo/translations/pl.json
+++ b/custom_components/openmeteo/translations/pl.json
@@ -14,7 +14,8 @@
           "update_interval": "Interwał aktualizacji (s)",
           "units": "Jednostki",
           "api_provider": "Dostawca API",
-          "area_name_override": "Nazwa obszaru"
+          "area_name_override": "Nazwa obszaru",
+          "use_place_as_device_name": "Użyj lokalizacji jako nazwy urządzenia"
         }
       }
     },
@@ -37,7 +38,8 @@
           "update_interval": "Interwał aktualizacji (s)",
           "units": "Jednostki",
           "api_provider": "Dostawca API",
-          "area_name_override": "Nazwa obszaru"
+          "area_name_override": "Nazwa obszaru",
+          "use_place_as_device_name": "Użyj lokalizacji jako nazwy urządzenia"
         }
       }
     },


### PR DESCRIPTION
## Summary
- use place name for device name and weather entity title
- simplify sensor names with `has_entity_name`
- add `use_place_as_device_name` option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca0574648832daec5d02e22cd655f