### PR TITLE
fix: reorder sensor description dataclass for Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.27
+- fix(sensor): reorder dataclass fields (Python 3.13) so required `value_fn` precedes optional fields; prevents import error
+- chore: mark dataclass `kw_only=True` for forward compatibility
+
 ## 1.3.25
 - feat: use reverse geocoded place name for entry titles; fallback to lat,lon only if geocode fails
 

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"

--- a/custom_components/openmeteo/sensor.py
+++ b/custom_components/openmeteo/sensor.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from datetime import datetime
+from typing import Any, Callable, Mapping
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
-    SensorStateClass,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -23,6 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
@@ -80,9 +83,28 @@ def _extra_attrs(data: dict) -> dict:
     }
 
 
-@dataclass
+@dataclass(kw_only=True)
 class OpenMeteoSensorDescription(SensorEntityDescription):
-    value_fn: Callable[[dict], Any]
+    key: str
+    value_fn: Callable[[dict[str, Any]], Any]
+    device_class: SensorDeviceClass | str | None = None
+    entity_category: EntityCategory | None = None
+    entity_registry_enabled_default: bool = True
+    entity_registry_visible_default: bool = True
+    force_update: bool = False
+    icon: str | None = None
+    has_entity_name: bool = False
+    name: str | None = None
+    translation_key: str | None = None
+    translation_placeholders: Mapping[str, str] | None = None
+    unit_of_measurement: str | None = None
+    last_reset: datetime | None = None
+    native_unit_of_measurement: str | None = None
+    options: list[str] | None = None
+    state_class: SensorStateClass | str | None = None
+    suggested_display_precision: int | None = None
+    suggested_unit_of_measurement: str | None = None
+    attr_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
 
 SENSOR_TYPES: dict[str, OpenMeteoSensorDescription] = {


### PR DESCRIPTION
## Summary
- reorder OpenMeteo sensor description dataclass so required `value_fn` precedes optional fields
- make dataclass keyword-only and update imports for Python 3.13
- bump integration version to 1.3.27

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca47cecc0832da6868733c2b55c9e