### PR TITLE
fix: refine naming and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.32
+- fix: correct override handling, prevent coords as names, stabilize tests
+
 ## 1.3.31
 - fix(naming): compute and store place for entities; weather name uses place only
 - fix(naming): sensors use static labels and entity names; remove dynamic names

--- a/custom_components/openmeteo/__init__.py
+++ b/custom_components/openmeteo/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_UNITS,
     CONF_UPDATE_INTERVAL,
     CONF_USE_PLACE_AS_DEVICE_NAME,
+    CONF_AREA_NAME_OVERRIDE,
     DEFAULT_API_PROVIDER,
     DEFAULT_MIN_TRACK_INTERVAL,
     DEFAULT_UNITS,
@@ -92,8 +93,10 @@ async def build_title(
     hass: HomeAssistant, entry: ConfigEntry, lat: float, lon: float
 ) -> str:
     """Build a title for the entry based on coordinates."""
-    override = entry.data.get("name_override")
-    geocode = entry.data.get("geocode_name", True)
+    override = entry.options.get(CONF_AREA_NAME_OVERRIDE)
+    if override is None:
+        override = entry.data.get(CONF_AREA_NAME_OVERRIDE)
+    geocode = entry.options.get("geocode_name", entry.data.get("geocode_name", True))
     store = _entry_store(hass, entry)
     if override:
         store["place_name"] = override

--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -79,9 +79,10 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass, _LOGGER, name="Open-Meteo", update_interval=timedelta(seconds=interval)
         )
         self.config_entry = entry
-        self.location_name: str | None = entry.options.get(
-            CONF_AREA_NAME_OVERRIDE, entry.data.get(CONF_AREA_NAME_OVERRIDE)
-        )
+        override = entry.options.get(CONF_AREA_NAME_OVERRIDE)
+        if override is None:
+            override = entry.data.get(CONF_AREA_NAME_OVERRIDE)
+        self.location_name: str | None = override
         self.provider: str = entry.options.get("api_provider", DEFAULT_API_PROVIDER)
         self._last_data: dict[str, Any] | None = None
         self._tracked_entity_id: str | None = None
@@ -116,7 +117,13 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if geocode_on
             else None
         )
+        _LOGGER.debug(
+            "Reverse geocode result for %s,%s: %s", latitude, longitude, place
+        )
         self.location_name = place
+        override = self.config_entry.options.get(CONF_AREA_NAME_OVERRIDE)
+        if override is None:
+            override = self.config_entry.data.get(CONF_AREA_NAME_OVERRIDE)
         store = (
             self.hass.data.setdefault(DOMAIN, {})
             .setdefault("entries", {})
@@ -131,7 +138,7 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await maybe_update_device_name(
             self.hass,
             self.config_entry,
-            place or f"{latitude:.5f},{longitude:.5f}",
+            override or place,
         )
         async_dispatcher_send(
             self.hass, f"openmeteo_place_updated_{self.config_entry.entry_id}"
@@ -176,7 +183,13 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if geocode_on
             else None
         )
+        _LOGGER.debug(
+            "Reverse geocode result for %s,%s: %s", latitude, longitude, place
+        )
         self.location_name = place
+        override = self.config_entry.options.get(CONF_AREA_NAME_OVERRIDE)
+        if override is None:
+            override = self.config_entry.data.get(CONF_AREA_NAME_OVERRIDE)
         store = (
             self.hass.data.setdefault(DOMAIN, {})
             .setdefault("entries", {})
@@ -195,7 +208,7 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await maybe_update_device_name(
             self.hass,
             self.config_entry,
-            place or f"{latitude:.5f},{longitude:.5f}",
+            override or place,
         )
         async_dispatcher_send(
             self.hass, f"openmeteo_place_updated_{self.config_entry.entry_id}"

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.31",
+  "version": "1.3.32",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"

--- a/custom_components/openmeteo/weather.py
+++ b/custom_components/openmeteo/weather.py
@@ -100,7 +100,6 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
         super().__init__(coordinator)
         self._config_entry = config_entry
         self._attr_unique_id = f"{config_entry.entry_id}-weather"
-        self._attr_name = None
         data = {**config_entry.data, **config_entry.options}
         self._use_place = data.get(
             CONF_USE_PLACE_AS_DEVICE_NAME, DEFAULT_USE_PLACE_AS_DEVICE_NAME

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -203,7 +203,7 @@ async def test_weather_entity_name_from_reverse_geocode(expected_lingering_timer
                 return_value="Radłów",
             ):
                 coordinator = OpenMeteoDataUpdateCoordinator(hass, entry)
-                await coordinator.async_config_entry_first_refresh()
+                await coordinator.async_refresh()
             weather = OpenMeteoWeather(coordinator, entry)
             weather.hass = hass
             weather.entity_id = "weather.test"


### PR DESCRIPTION
## Summary
- respect area name override from options and avoid coordinate device names
- refresh entry title/device via geocode and dispatcher updates
- stabilize tests and bump integration to 1.3.32

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acbadbb838832dbb0d90b4200d674d