### PR TITLE
feat: stabilize entity ids and migrate legacy entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.37
+- feat: stałe entity_id bez miejscowości; domyślnie w nazwach dopisek lokalizacji; migracja usuwająca miejscowości z entity_id; ikony/device_class uzupełnione
+
 ## 1.3.32
 - fix: correct override handling, prevent coords as names, stabilize tests
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ cards:
       - type: weather
         entity: weather.open_meteo_home
       - type: entity
-        entity: sensor.open_meteo_indeks_uv
+        entity: sensor.open_meteo_uv_index
         name: UV
       - type: entity
         entity: sensor.open_meteo_prawdopodobienstwo_opadow

--- a/custom_components/openmeteo/config_flow.py
+++ b/custom_components/openmeteo/config_flow.py
@@ -152,6 +152,7 @@ class OpenMeteoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if self._mode != MODE_STATIC:
                     use_place = data.pop(CONF_USE_PLACE_AS_DEVICE_NAME, True)
                     options[CONF_USE_PLACE_AS_DEVICE_NAME] = use_place
+                options[CONF_SHOW_PLACE_NAME] = True
                 return self.async_create_entry(title="", data=data, options=options)
 
         schema = _build_schema(self.hass, self._mode, defaults)
@@ -178,6 +179,7 @@ class OpenMeteoOptionsFlow(config_entries.OptionsFlow):
         # Migrate old configs that stored an empty string for the entity
         if self._options.get(CONF_ENTITY_ID) == "":
             self._options[CONF_ENTITY_ID] = None
+        self._options.setdefault(CONF_SHOW_PLACE_NAME, DEFAULT_SHOW_PLACE_NAME)
         self._mode = eff.get(CONF_MODE, MODE_STATIC)
 
     async def async_step_init(

--- a/custom_components/openmeteo/const.py
+++ b/custom_components/openmeteo/const.py
@@ -110,6 +110,28 @@ API_URL = URL  # alias dla starszych importów
 # Platforms
 PLATFORMS = ["weather", "sensor"]
 
+# Legacy sensor entity ID prefixes mapped to current keys
+LEGACY_SENSOR_PREFIXES = {
+    "cisnienie": "pressure",
+    "indeks_uv": "uv_index",
+    "kierunek_wiatru": "wind_direction",
+    "porywy_wiatru": "wind_gust",
+    "predkosc_wiatru": "wind_speed",
+    "punkt_rosy": "dew_point",
+    "suma_opadow": "precipitation",
+    "prawdopodobienstwo_opadow": "precipitation_probability",
+    "temperatura": "temperature",
+    "temperatura_odczuwalna": "apparent_temperature",
+    "widzialnosc": "visibility",
+    "wilgotnosc": "humidity",
+    "wschod_slonca": "sunrise",
+    "zachod_slonca": "sunset",
+    "lokalizacja": "location",
+    "zachmurzenie": "cloud_cover",
+    "promieniowanie_sloneczne": "solar_radiation",
+    "pokrywa_sniezna": "snow_depth",
+}
+
 # Weather code → HA condition mapping
 CONDITION_MAP = {
     0: ATTR_CONDITION_SUNNY,  # Clear sky

--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -143,6 +143,8 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if override is None:
             override = entry.data.get(CONF_AREA_NAME_OVERRIDE)
         self.location_name: str | None = override
+        self.latitude: float | None = None
+        self.longitude: float | None = None
         self.provider: str = entry.options.get("api_provider", DEFAULT_API_PROVIDER)
         self._last_data: dict[str, Any] | None = None
         self._tracked_entity_id: str | None = None
@@ -169,6 +171,8 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         latitude, longitude, _ = await resolve_coords(
             self.hass, self.config_entry
         )
+        self.latitude = latitude
+        self.longitude = longitude
         show_place = opts.get(CONF_SHOW_PLACE_NAME, DEFAULT_SHOW_PLACE_NAME)
         provider = opts.get(CONF_GEOCODER_PROVIDER, DEFAULT_GEOCODER_PROVIDER)
         place = (

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.36",
+  "version": "1.3.37",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_entity_registry_migration(expected_lingering_timers):
+    from pytest_homeassistant_custom_component.common import (
+        MockConfigEntry,
+        async_test_home_assistant,
+    )
+    from homeassistant.helpers import entity_registry as er
+    from custom_components.openmeteo import _migrate_entity_registry
+    from custom_components.openmeteo.const import DOMAIN, CONF_MODE, MODE_STATIC
+    from homeassistant.util import dt as dt_util
+    from unittest.mock import patch
+
+    with patch("homeassistant.util.dt.get_time_zone", return_value=dt_util.UTC):
+        async with async_test_home_assistant() as hass:
+            entry = MockConfigEntry(
+                domain=DOMAIN,
+                data={CONF_MODE: MODE_STATIC},
+                options={},
+                title="X",
+            )
+            entry.add_to_hass(hass)
+            registry = er.async_get(hass)
+            sensor_entry = registry.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                "legacy_uv",
+                suggested_object_id="indeks_uv_castrop_rauxel_de",
+                config_entry=entry,
+            )
+            weather_entry = registry.async_get_or_create(
+                "weather",
+                DOMAIN,
+                "legacy_weather",
+                suggested_object_id="open_meteo_castrop_rauxel_de",
+                config_entry=entry,
+            )
+            old_sensor_id = sensor_entry.id
+            old_weather_id = weather_entry.id
+
+            await _migrate_entity_registry(hass, entry)
+
+            new_sensor = registry.async_get("sensor.open_meteo_uv_index")
+            assert new_sensor is not None
+            assert new_sensor.id == old_sensor_id
+            assert new_sensor.unique_id == f"{entry.entry_id}_uv_index"
+            new_weather = registry.async_get("weather.open_meteo")
+            assert new_weather is not None
+            assert new_weather.id == old_weather_id
+            assert new_weather.unique_id == f"{entry.entry_id}_weather"
+            await hass.async_stop()


### PR DESCRIPTION
## Summary
- ensure all entities use stable entry-based IDs without location names
- show reverse-geocoded place in entity names with configurable option
- migrate legacy entity and unique IDs and fill missing icons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad2e6aa568832dbacced92b4914721