### PR TITLE
Add hourly snow depth & solar radiation support

### DIFF
--- a/custom_components/openmeteo/const.py
+++ b/custom_components/openmeteo/const.py
@@ -99,6 +99,8 @@ DEFAULT_HOURLY_VARIABLES = [
     "is_day",
     "apparent_temperature",
     "uv_index",
+    "shortwave_radiation",
+    "snow_depth",
 ]
 
 # API

--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -389,6 +389,8 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hourly = self._last_data.setdefault("hourly", {})
             hourly.setdefault("time", [])
             hourly.setdefault("uv_index", [])
+            hourly.setdefault("shortwave_radiation", [])
+            hourly.setdefault("snow_depth", [])
             return self._last_data
         except UpdateFailed:
             if self._last_data is not None:

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.42",
+  "version": "1.3.43",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"


### PR DESCRIPTION
## Summary
- Include `shortwave_radiation` and `snow_depth` in default hourly API query
- Ensure coordinator always exposes radiation and snow depth arrays
- Bump integration version to 1.3.43

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ada6a4cfbc832d8b56aa641d91fe55