### PR TITLE
feat: improve options flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.58 (2025-09-05)
+- fix(options): two-step OptionsFlow; edit mode + fields; save to entry.options
+- chore(flow): single async_get_options_flow exported from __init__.py
+- fix(config): reload on options change (no direct coordinator access)
+- i18n: add labels/errors for new options
+
 ## 1.3.56
 - fix(flow): entity selector without default; Options/gear available again
 

--- a/custom_components/openmeteo/__init__.py
+++ b/custom_components/openmeteo/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import OpenMeteoDataUpdateCoordinator
+from .config_flow import OpenMeteoOptionsFlowHandler
 
 
 CONFIG_ENTRY_VERSION = 2
@@ -133,7 +134,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         pass
     await coordinator._resubscribe_tracked_entity(entry.options.get("entity_id"))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(_options_update_listener))
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     return True
 
 
@@ -163,21 +165,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def _options_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    coord = (
-        hass.data.get(DOMAIN, {})
-        .get("entries", {})
-        .get(entry.entry_id, {})
-        .get("coordinator")
-    )
-    if coord:
-        hass.async_create_task(coord.async_options_updated())
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
-from .config_flow import OpenMeteoOptionsFlowHandler as _OM_OptionsFlowHandler
-
-
-async def async_get_options_flow(config_entry):
-    return _OM_OptionsFlowHandler(config_entry)
+async def async_get_options_flow(config_entry: ConfigEntry) -> OpenMeteoOptionsFlowHandler:
+    return OpenMeteoOptionsFlowHandler(config_entry)
 
 

--- a/custom_components/openmeteo/manifest.json
+++ b/custom_components/openmeteo/manifest.json
@@ -8,7 +8,7 @@
     "@shockwave9315"
   ],
   "iot_class": "cloud_polling",
-  "version": "1.3.56",
+  "version": "1.3.58",
   "requirements": [
     "aiohttp>=3.8.0",
     "async-timeout>=4.0.0"

--- a/custom_components/openmeteo/translations/en.json
+++ b/custom_components/openmeteo/translations/en.json
@@ -28,23 +28,32 @@
     "step": {
       "init": {
         "title": "Open-Meteo options",
-        "data": {
-          "mode": "Mode",
-          "latitude": "Latitude",
-          "longitude": "Longitude",
-          "entity_id": "Tracker entity",
-          "min_track_interval": "Min track interval (min)",
-          "update_interval": "Update interval (s)",
-          "units": "Units",
-          "area_name_override": "Area name override",
-          "use_place_as_device_name": "Use place as device name"
-        }
+        "description": "Select the mode to edit settings."
+      },
+      "mode_details": {
+        "title": "Mode settings"
       }
     },
     "error": {
-      "missing_location": "Latitude and longitude are required",
-      "missing_entity": "Tracking entity is required",
-      "invalid_entity": "Entity has no GPS coordinates"
+      "latlon_required": "Please provide both latitude and longitude.",
+      "entity_required": "Please select a tracking entity (device_tracker or person)."
+    },
+    "data": {
+      "mode": "Mode",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "entity_id": "Tracking entity",
+      "min_track_interval": "Minimum tracking interval (minutes)",
+      "update_interval": "Update interval (minutes)",
+      "units": "Units",
+      "use_place_as_device_name": "Use place name as device name",
+      "show_place_name": "Show place name in entity names"
+    },
+    "select": {
+      "static": "Static",
+      "track": "Track",
+      "metric": "Metric",
+      "imperial": "Imperial"
     }
   },
   "uv_index": { "name": "UV Index" }

--- a/custom_components/openmeteo/translations/pl.json
+++ b/custom_components/openmeteo/translations/pl.json
@@ -28,23 +28,32 @@
     "step": {
       "init": {
         "title": "Opcje Open-Meteo",
-        "data": {
-          "mode": "Tryb",
-          "latitude": "Szerokość geograficzna",
-          "longitude": "Długość geograficzna",
-          "entity_id": "Encja trackera",
-          "min_track_interval": "Min. odstęp śledzenia (min)",
-          "update_interval": "Interwał aktualizacji (s)",
-          "units": "Jednostki",
-          "area_name_override": "Nazwa obszaru",
-          "use_place_as_device_name": "Użyj lokalizacji jako nazwy urządzenia"
-        }
+        "description": "Wybierz tryb, aby edytować ustawienia."
+      },
+      "mode_details": {
+        "title": "Ustawienia trybu"
       }
     },
     "error": {
-      "missing_location": "Wymagana szerokość i długość geograficzna",
-      "missing_entity": "Wymagana encja do śledzenia",
-      "invalid_entity": "Encja nie ma współrzędnych GPS"
+      "latlon_required": "Podaj szerokość i długość geograficzną.",
+      "entity_required": "Wybierz encję śledzenia (device_tracker lub person)."
+    },
+    "data": {
+      "mode": "Tryb",
+      "latitude": "Szerokość geograficzna",
+      "longitude": "Długość geograficzna",
+      "entity_id": "Encia śledząca",
+      "min_track_interval": "Minimalny interwał śledzenia (minuty)",
+      "update_interval": "Interwał odświeżania (minuty)",
+      "units": "Jednostki",
+      "use_place_as_device_name": "Użyj nazwy miejscowości jako nazwy urządzenia",
+      "show_place_name": "Pokazuj nazwę miejscowości w nazwach encji"
+    },
+    "select": {
+      "static": "Statyczny",
+      "track": "Śledzenie",
+      "metric": "Metryczne",
+      "imperial": "Imperialne"
     }
   },
   "uv_index": { "name": "Indeks UV" }


### PR DESCRIPTION
## Summary
- allow editing Open-Meteo options in two steps and store mode in options
- reload config entry when options change and export options flow from `__init__`
- update translations and changelog for v1.3.58

## Testing
- `pytest` *(fails: coroutine raised StopIteration; lingering timer)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a73ae00832db1d9416b14689b39