### PR TITLE
Improve location naming and device entity slugs

### DIFF
--- a/custom_components/openmeteo/config_flow.py
+++ b/custom_components/openmeteo/config_flow.py
@@ -1,4 +1,4 @@
-"""Config and options flows for Open-Meteo."""
+"""Config and options flows for the Open-Meteo integration."""
 from __future__ import annotations
 
 from typing import Any
@@ -6,12 +6,12 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 
 from .const import (
+    CONF_API_PROVIDER,
     CONF_AREA_NAME_OVERRIDE,
     CONF_ENTITY_ID,
     CONF_MIN_TRACK_INTERVAL,
@@ -19,19 +19,26 @@ from .const import (
     CONF_UNITS,
     CONF_UPDATE_INTERVAL,
     CONF_USE_PLACE_AS_DEVICE_NAME,
+    DEFAULT_API_PROVIDER,
     DEFAULT_MIN_TRACK_INTERVAL,
     DEFAULT_UNITS,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     MODE_STATIC,
     MODE_TRACK,
-    CONF_API_PROVIDER,
-    DEFAULT_API_PROVIDER,
 )
+from .coordinator import async_reverse_geocode
 
 
-def _build_schema(hass: HomeAssistant, mode: str, defaults: dict[str, Any]) -> vol.Schema:
-    """Build a schema for config/option flows."""
+def _build_schema(
+    hass: HomeAssistant,
+    mode: str,
+    defaults: dict[str, Any],
+    *,
+    include_use_place: bool = True,
+) -> vol.Schema:
+    """Build a schema for the config and options flow."""
+
     if mode == MODE_TRACK:
         data: dict[Any, Any] = {
             vol.Required(
@@ -41,9 +48,7 @@ def _build_schema(hass: HomeAssistant, mode: str, defaults: dict[str, Any]) -> v
             ),
             vol.Optional(
                 CONF_MIN_TRACK_INTERVAL,
-                default=defaults.get(
-                    CONF_MIN_TRACK_INTERVAL, DEFAULT_MIN_TRACK_INTERVAL
-                ),
+                default=defaults.get(CONF_MIN_TRACK_INTERVAL, DEFAULT_MIN_TRACK_INTERVAL),
             ): vol.All(vol.Coerce(int), vol.Range(min=1)),
         }
     else:
@@ -58,34 +63,87 @@ def _build_schema(hass: HomeAssistant, mode: str, defaults: dict[str, Any]) -> v
             ): vol.All(vol.Coerce(float), vol.Range(min=-180, max=180)),
         }
 
-    data.update(
-        {
-            vol.Required(
-                CONF_UPDATE_INTERVAL,
-                default=defaults.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
-            ): vol.All(vol.Coerce(int), vol.Range(min=60)),
-            vol.Required(
-                CONF_UNITS, default=defaults.get(CONF_UNITS, DEFAULT_UNITS)
-            ): vol.In(["metric", "imperial"]),
-            vol.Required(
-                CONF_API_PROVIDER,
-                default=defaults.get(CONF_API_PROVIDER, DEFAULT_API_PROVIDER),
-            ): vol.In(["open_meteo"]),
-            vol.Optional(
-                CONF_AREA_NAME_OVERRIDE,
-                default=defaults.get(CONF_AREA_NAME_OVERRIDE, ""),
-            ): str,
-            vol.Required(
-                CONF_USE_PLACE_AS_DEVICE_NAME,
-                default=defaults.get(CONF_USE_PLACE_AS_DEVICE_NAME, True),
-            ): bool,
-        }
-    )
+    extra = {
+        vol.Required(
+            CONF_UPDATE_INTERVAL,
+            default=defaults.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        ): vol.All(vol.Coerce(int), vol.Range(min=60)),
+        vol.Required(
+            CONF_UNITS, default=defaults.get(CONF_UNITS, DEFAULT_UNITS)
+        ): vol.In(["metric", "imperial"]),
+        vol.Required(
+            CONF_API_PROVIDER,
+            default=defaults.get(CONF_API_PROVIDER, DEFAULT_API_PROVIDER),
+        ): vol.In(["open_meteo"]),
+        vol.Optional(
+            CONF_AREA_NAME_OVERRIDE,
+            default=defaults.get(CONF_AREA_NAME_OVERRIDE, ""),
+        ): str,
+    }
+    if include_use_place:
+        extra[vol.Required(
+            CONF_USE_PLACE_AS_DEVICE_NAME,
+            default=defaults.get(CONF_USE_PLACE_AS_DEVICE_NAME, True),
+        )] = bool
+
+    data.update(extra)
     return vol.Schema(data)
 
 
+async def _async_guess_title(
+    hass: HomeAssistant, mode: str, data: dict[str, Any]
+) -> str:
+    """Derive a friendly title for the entry based on provided data."""
+
+    override = (data.get(CONF_AREA_NAME_OVERRIDE) or "").strip()
+    if override:
+        return override
+
+    try:
+        if mode == MODE_TRACK:
+            entity_id = data.get(CONF_ENTITY_ID)
+            if entity_id:
+                state = hass.states.get(entity_id)
+                if state:
+                    lat = state.attributes.get("latitude")
+                    lon = state.attributes.get("longitude")
+                    try:
+                        lat_f = float(lat) if lat is not None else None
+                        lon_f = float(lon) if lon is not None else None
+                    except (TypeError, ValueError):
+                        lat_f = lon_f = None
+
+                    if lat_f is not None and lon_f is not None:
+                        place = await async_reverse_geocode(hass, lat_f, lon_f)
+                        if place:
+                            return place
+                        return f"Open-Meteo: {lat_f:.4f},{lon_f:.4f}"
+
+                    friendly = (
+                        state.attributes.get("friendly_name")
+                        or state.name
+                        or entity_id
+                    )
+                    return f"Open-Meteo: {friendly}"
+            return "Open-Meteo: Śledzenie"
+
+        lat = data.get(CONF_LATITUDE)
+        lon = data.get(CONF_LONGITUDE)
+        if lat is None or lon is None:
+            return "Open-Meteo"
+
+        lat_f = float(lat)
+        lon_f = float(lon)
+        place = await async_reverse_geocode(hass, lat_f, lon_f)
+        if place:
+            return place
+        return f"Open-Meteo: {lat_f:.4f},{lon_f:.4f}"
+    except Exception:  # pragma: no cover - defensive
+        return "Open-Meteo"
+
+
 class OpenMeteoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for the integration."""
+    """Handle the configuration flow for Open-Meteo."""
 
     VERSION = 2
 
@@ -95,7 +153,8 @@ class OpenMeteoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """First step: choose tracking mode."""
+        """Initial step asking for operating mode."""
+
         if user_input is not None:
             self._mode = user_input[CONF_MODE]
             return await self.async_step_mode_details()
@@ -108,7 +167,8 @@ class OpenMeteoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_mode_details(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """Second step: gather fields for the selected mode."""
+        """Collect details specific to the chosen mode."""
+
         errors: dict[str, str] = {}
         defaults = user_input or {}
 
@@ -122,16 +182,22 @@ class OpenMeteoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if not state or "latitude" not in state.attributes or "longitude" not in state.attributes:
                         errors[CONF_ENTITY_ID] = "invalid_entity"
             else:
-                if not user_input.get(CONF_LATITUDE):
+                if user_input.get(CONF_LATITUDE) in (None, ""):
                     errors[CONF_LATITUDE] = "required"
-                if not user_input.get(CONF_LONGITUDE):
+                if user_input.get(CONF_LONGITUDE) in (None, ""):
                     errors[CONF_LONGITUDE] = "required"
 
             if not errors:
                 data = {**user_input, CONF_MODE: self._mode}
-                return self.async_create_entry(title=await self._guess_title(self._mode, data), data=data)
+                title = await _async_guess_title(self.hass, self._mode, data)
+                return self.async_create_entry(title=title, data=data)
 
-        schema = _build_schema(self.hass, self._mode, defaults)
+        schema = _build_schema(
+            self.hass,
+            self._mode,
+            defaults,
+            include_use_place=self._mode == MODE_TRACK,
+        )
         return self.async_show_form(
             step_id="mode_details", data_schema=schema, errors=errors
         )
@@ -140,216 +206,74 @@ class OpenMeteoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(
         config_entry: config_entries.ConfigEntry,
-    ) -> OpenMeteoOptionsFlow:
+    ) -> config_entries.OptionsFlow:
         return OpenMeteoOptionsFlow(config_entry)
 
 
-
-    async def _guess_title(self, mode: str, data: dict) -> str:
-        """Derive a smart title for the config entry."""
-        try:
-            if mode == MODE_TRACK and data.get(CONF_ENTITY_ID):
-                ent_id = data.get(CONF_ENTITY_ID)
-                st = self.hass.states.get(ent_id)
-                if st:
-                    fn = st.attributes.get("friendly_name") or st.name or ent_id
-                    return f"Open-Meteo: {fn}"
-                return "Open-Meteo: Śledzenie"
-            # STATIC
-            lat = float(data.get(CONF_LATITUDE))
-            lon = float(data.get(CONF_LONGITUDE))
-            session = async_get_clientsession(self.hass)
-            url = (
-                "https://geocoding-api.open-meteo.com/v1/reverse"
-                f"?latitude={lat:.5f}&longitude={lon:.5f}&language=pl&format=json"
-            )
-            async with session.get(url, timeout=10) as resp:
-                if resp.status == 200:
-                    js = await resp.json()
-                    results = js.get("results") or []
-                    if results:
-                        r = results[0]
-                        name = r.get("name") or r.get("admin2") or r.get("admin1")
-                        cc = r.get("country_code")
-                        if name and cc:
-                            return f"{name}, {cc}"
-                        if name:
-                            return name
-            return f"Open-Meteo: {lat:.4f},{lon:.4f}"
-        except Exception:
-            return "Open-Meteo"
-    
 class OpenMeteoOptionsFlow(config_entries.OptionsFlow):
-    """Options flow allowing to tweak settings after setup."""
+    """Handle the options flow after the integration is set up."""
 
     def __init__(self, entry: config_entries.ConfigEntry) -> None:
         self._entry = entry
-        # Copy options so we can safely mutate defaults
-        self._options: dict[str, Any] = dict(entry.options)
-        # Migrate old configs that stored an empty string for the entity
-        if self._options.get(CONF_ENTITY_ID) == "":
-            self._options[CONF_ENTITY_ID] = None
-        # Default mode comes only from saved options
-        self._mode = self._options.get(CONF_MODE, MODE_STATIC)
+        merged = {**entry.data, **entry.options}
+        self._mode = merged.get(CONF_MODE, MODE_STATIC)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """First step: choose tracking mode."""
+        """First step of the options flow: choose mode."""
 
         if user_input is not None:
             self._mode = user_input[CONF_MODE]
             return await self.async_step_mode_details()
+
         schema = vol.Schema(
-            {
-                vol.Required(CONF_MODE, default=self._mode): vol.In(
-                    [MODE_STATIC, MODE_TRACK]
-                )
-            }
+            {vol.Required(CONF_MODE, default=self._mode): vol.In([MODE_STATIC, MODE_TRACK])}
         )
         return self.async_show_form(step_id="init", data_schema=schema)
-    async def async_step_mode_details(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.FlowResult:
-        """Second step: gather fields for the selected mode."""
-        errors: dict[str, str] = {}
-        defaults = user_input or {}
-
-        if user_input is not None:
-            if self._mode == MODE_TRACK:
-                entity = user_input.get(CONF_ENTITY_ID)
-                if not entity:
-                    errors[CONF_ENTITY_ID] = "required"
-                else:
-                    state = self.hass.states.get(entity)
-                    if not state or "latitude" not in state.attributes or "longitude" not in state.attributes:
-                        errors[CONF_ENTITY_ID] = "invalid_entity"
-            else:
-                if not user_input.get(CONF_LATITUDE):
-                    errors[CONF_LATITUDE] = "required"
-                if not user_input.get(CONF_LONGITUDE):
-                    errors[CONF_LONGITUDE] = "required"
-
-            if not errors:
-                # Persist options update
-                data = {**self._options, **user_input, CONF_MODE: self._mode}
-                return self.async_create_entry(title=await self._guess_title(self._mode, data), data=data)
-
-        schema = _build_schema(self.hass, self._mode, defaults)
-        return self.async_show_form(step_id="mode_details", data_schema=schema, errors=errors)
 
     async def async_step_mode_details(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """Second step: gather fields for the selected mode."""
+        """Collect mode-specific options."""
+
+        merged_defaults = {**self._entry.data, **self._entry.options}
+        defaults = dict(merged_defaults)
         errors: dict[str, str] = {}
 
-        data = {**self._entry.data, **self._entry.options}
-        defaults = user_input or data
-
-
         if user_input is not None:
+            defaults.update(user_input)
+
             if self._mode == MODE_TRACK:
                 if not user_input.get(CONF_ENTITY_ID):
                     errors[CONF_ENTITY_ID] = "required"
             else:
-                if not user_input.get(CONF_LATITUDE):
+                if user_input.get(CONF_LATITUDE) in (None, ""):
                     errors[CONF_LATITUDE] = "required"
-                if not user_input.get(CONF_LONGITUDE):
+                if user_input.get(CONF_LONGITUDE) in (None, ""):
                     errors[CONF_LONGITUDE] = "required"
 
             if not errors:
-                new_options: dict[str, Any] = {**self._entry.options}
-                if self._mode == MODE_TRACK:
+                new_options: dict[str, Any] = dict(self._entry.options)
 
+                if self._mode == MODE_TRACK:
                     new_options.pop(CONF_LATITUDE, None)
                     new_options.pop(CONF_LONGITUDE, None)
                 else:
-
                     new_options.pop(CONF_ENTITY_ID, None)
                     new_options.pop(CONF_MIN_TRACK_INTERVAL, None)
+
                 new_options.update(user_input)
                 new_options[CONF_MODE] = self._mode
-                return self.async_create_entry(title=await self._guess_title(self._mode, new_options), data=new_options)
 
-        if self._mode == MODE_TRACK:
-            schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_ENTITY_ID,
+                return self.async_create_entry(title="", data=new_options)
 
-                        default=defaults.get(CONF_ENTITY_ID, ""),
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(
-                            domain=["device_tracker", "person"]
-
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_MIN_TRACK_INTERVAL,
-                        default=defaults.get(
-                            CONF_MIN_TRACK_INTERVAL, DEFAULT_MIN_TRACK_INTERVAL
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-                    vol.Required(
-                        CONF_UPDATE_INTERVAL,
-                        default=defaults.get(
-                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=60)),
-                    vol.Required(
-                        CONF_UNITS, default=defaults.get(CONF_UNITS, DEFAULT_UNITS)
-                    ): vol.In(["metric", "imperial"]),
-                    vol.Required(
-                        CONF_API_PROVIDER,
-                        default=defaults.get(
-                            CONF_API_PROVIDER, DEFAULT_API_PROVIDER
-                        ),
-                    ): vol.In(["open_meteo"]),
-                    vol.Optional(
-                        CONF_AREA_NAME_OVERRIDE,
-                        default=defaults.get(CONF_AREA_NAME_OVERRIDE, ""),
-                    ): str,
-                }
-            )
-        else:
-            schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_LATITUDE,
-                        default=defaults.get(
-                            CONF_LATITUDE, self.hass.config.latitude
-                        ),
-                    ): vol.All(vol.Coerce(float), vol.Range(min=-90, max=90)),
-                    vol.Required(
-                        CONF_LONGITUDE,
-                        default=defaults.get(
-                            CONF_LONGITUDE, self.hass.config.longitude
-                        ),
-                    ): vol.All(vol.Coerce(float), vol.Range(min=-180, max=180)),
-                    vol.Required(
-                        CONF_UPDATE_INTERVAL,
-                        default=defaults.get(
-                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=60)),
-                    vol.Required(
-                        CONF_UNITS, default=defaults.get(CONF_UNITS, DEFAULT_UNITS)
-                    ): vol.In(["metric", "imperial"]),
-                    vol.Required(
-                        CONF_API_PROVIDER,
-                        default=defaults.get(
-                            CONF_API_PROVIDER, DEFAULT_API_PROVIDER
-                        ),
-                    ): vol.In(["open_meteo"]),
-                    vol.Optional(
-                        CONF_AREA_NAME_OVERRIDE,
-                        default=defaults.get(CONF_AREA_NAME_OVERRIDE, ""),
-                    ): str,
-                }
-            )
-
+        schema = _build_schema(
+            self.hass,
+            self._mode,
+            defaults,
+            include_use_place=self._mode == MODE_TRACK,
+        )
         return self.async_show_form(
             step_id="mode_details", data_schema=schema, errors=errors
         )
-

--- a/custom_components/openmeteo/weather.py
+++ b/custom_components/openmeteo/weather.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.weather import (
@@ -16,7 +17,6 @@ from homeassistant.components.weather import (
     WeatherEntity,
     WeatherEntityFeature,
 )
-from homeassistant.helpers import device_registry as dr
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfLength,
@@ -25,28 +25,31 @@ from homeassistant.const import (
     UnitOfSpeed,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from datetime import datetime
 from homeassistant.util import dt as dt_util
-from .helpers import hourly_at_now as _hourly_at_now
+from homeassistant.util import slugify
 
-from .coordinator import OpenMeteoDataUpdateCoordinator
-from .helpers import maybe_update_device_name
 from .const import (
+    ATTRIBUTION,
     CONDITION_MAP,
-    DOMAIN,
-    CONF_MODE,
-    CONF_MIN_TRACK_INTERVAL,
-    CONF_API_PROVIDER,
+    CONF_AREA_NAME_OVERRIDE,
     CONF_ENTITY_ID,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_MIN_TRACK_INTERVAL,
+    CONF_MODE,
     CONF_TRACKED_ENTITY_ID,
     CONF_USE_PLACE_AS_DEVICE_NAME,
+    DEFAULT_MIN_TRACK_INTERVAL,
+    DOMAIN,
     MODE_STATIC,
     MODE_TRACK,
-    DEFAULT_MIN_TRACK_INTERVAL,
 )
+from .coordinator import OpenMeteoDataUpdateCoordinator
+from .helpers import hourly_at_now as _hourly_at_now, maybe_update_device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,12 +59,15 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
+    """Set up the Open-Meteo weather entity from a config entry."""
+
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities([OpenMeteoWeather(coordinator, config_entry)])
 
 
 def _map_condition(weather_code: int | None, is_day: int | None = 1) -> str | None:
     """Map Open-Meteo weather code to Home Assistant condition."""
+
     if weather_code is None:
         return None
     if weather_code in (0, 1) and is_day == 0:
@@ -69,66 +75,38 @@ def _map_condition(weather_code: int | None, is_day: int | None = 1) -> str | No
     return CONDITION_MAP.get(weather_code)
 
 
-class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
-    """Implementation of an Open-Meteo weather entity."""
+class OpenMeteoWeather(CoordinatorEntity[OpenMeteoDataUpdateCoordinator], WeatherEntity):
+    """Representation of the Open-Meteo weather entity."""
 
-    _attr_attribution = "Weather data provided by Open-Meteo"
+    _attr_attribution = ATTRIBUTION
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
     _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
     _attr_native_visibility_unit = UnitOfLength.KILOMETERS
     _attr_native_pressure_unit = UnitOfPressure.HPA
-    
+
     _attr_supported_features = (
-        WeatherEntityFeature.FORECAST_DAILY
-        | WeatherEntityFeature.FORECAST_HOURLY
+        WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
     )
     try:
         _attr_supported_features |= WeatherEntityFeature.HOURLY_PRECIPITATION
-    except AttributeError:
+    except AttributeError:  # pragma: no cover - older HA versions
         pass
-        
-    def _update_device_name(self) -> None:
-        """Update the device name based on location if enabled in options."""
-        if not hasattr(self, 'hass') or not hasattr(self, '_config_entry'):
-            return
-        if not self._config_entry.options.get(CONF_USE_PLACE_AS_DEVICE_NAME, True):
-            return
-        loc = (self.coordinator.data or {}).get("location_name")
-        if loc:
-            self.hass.async_create_task(
-                maybe_update_device_name(self.hass, self._config_entry, loc)
-            )
-        
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to hass."""
-        await super().async_added_to_hass()
-        
-        
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        
-        self.async_write_ha_state()
-
 
     def __init__(
         self, coordinator: OpenMeteoDataUpdateCoordinator, config_entry: ConfigEntry
     ) -> None:
-        """Initialize the weather entity."""
         super().__init__(coordinator)
         self._config_entry = config_entry
-        # Stabilne entity_id przy pierwszym utworzeniu (np. weather.pogoda)
-        self._attr_suggested_object_id = "open_meteo"
-        self._attr_unique_id = f"{config_entry.entry_id}-weather"
-        self.___unused_flag = True
-        # Freeze name during first add so entity_id uses suggested_object_id
-        
         self._attr_has_entity_name = False
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, config_entry.entry_id)},
-            "name": device_name,
-            "manufacturer": "Open-Meteo",
-        }
+        self._attr_unique_id = f"{config_entry.entry_id}-weather"
+        self._attr_suggested_object_id = self._derive_object_id()
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            name=self._default_device_name(),
+            manufacturer="Open-Meteo",
+        )
+
         data = {**config_entry.data, **config_entry.options}
         mode = data.get(CONF_MODE)
         if not mode:
@@ -143,92 +121,84 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
         )
         self._provider = coordinator.provider
 
-    
-    @property
-    def name(self) -> str:
+    def _default_device_name(self) -> str:
+        """Return the best human-friendly device name available."""
+
+        for candidate in (
+            (self.coordinator.data or {}).get("location_name"),
+            self._config_entry.options.get(CONF_AREA_NAME_OVERRIDE),
+            self._config_entry.title,
+        ):
+            if candidate:
+                return str(candidate)
+
+        data = {**self._config_entry.data, **self._config_entry.options}
+        lat = data.get(CONF_LATITUDE)
+        lon = data.get(CONF_LONGITUDE)
         try:
-            dev = dr.async_get(self.hass).async_get_device(identifiers={(DOMAIN, self._config_entry.entry_id)})
-            if dev:
-                nm = dev.name_by_user or (self.coordinator.data or {}).get("location_name") or dev.name
-                if nm:
-                    return nm
-        except Exception:
-            pass
-        return (self.coordinator.data or {}).get("location_name") or self._config_entry.title or "Open-Meteo"
+            return f"{float(lat):.2f},{float(lon):.2f}"
+        except (TypeError, ValueError):
+            return "Open-Meteo"
 
-    def available(self) -> bool:
-        """Return if entity is available."""
-        if not self.coordinator.data:
-            return False
-        return self.coordinator.last_update_success
+    def _derive_object_id(self) -> str:
+        """Return a slugified object id based on location data."""
 
-    @property
-    def native_temperature(self) -> float | None:
-        """Return the current temperature."""
-        cw = self.coordinator.data.get("current_weather", {})
-        temp = cw.get("temperature")
-        return round(temp, 1) if isinstance(temp, (int, float)) else None
+        for candidate in (
+            self._config_entry.options.get(CONF_AREA_NAME_OVERRIDE),
+            self._config_entry.title,
+        ):
+            slug = slugify(candidate or "")
+            if slug:
+                return slug
 
-    @property
-    def native_pressure(self) -> float | None:
-        val = _hourly_at_now(self.coordinator.data, "pressure_msl")
-        return round(val, 1) if isinstance(val, (int, float)) else None
+        data = {**self._config_entry.data, **self._config_entry.options}
+        lat = data.get(CONF_LATITUDE)
+        lon = data.get(CONF_LONGITUDE)
+        try:
+            slug = slugify(f"{float(lat):.4f}_{float(lon):.4f}")
+        except (TypeError, ValueError):
+            slug = "open_meteo"
+        return slug or "open_meteo"
 
-    @property
-    def native_wind_speed(self) -> float | None:
-        """Return the current wind speed."""
-        cw = self.coordinator.data.get("current_weather", {})
-        ws = cw.get("windspeed")
-        return round(ws, 1) if isinstance(ws, (int, float)) else None
+    def _update_device_name(self) -> None:
+        """Update the device name in the registry when the place changes."""
 
-    @property
-    def wind_bearing(self) -> float | None:
-        """Return the current wind bearing."""
-        cw = self.coordinator.data.get("current_weather", {})
-        wb = cw.get("winddirection")
-        return round(wb, 1) if isinstance(wb, (int, float)) else None
+        if not self.hass:
+            return
+        if not self._config_entry.options.get(CONF_USE_PLACE_AS_DEVICE_NAME, True):
+            return
 
-    @property
-    def native_visibility(self) -> float | None:
-        vis = _hourly_at_now(self.coordinator.data, "visibility")
-        return round(vis / 1000, 2) if isinstance(vis, (int, float)) else None
+        location = (self.coordinator.data or {}).get("location_name")
+        if location:
+            self.hass.async_create_task(
+                maybe_update_device_name(self.hass, self._config_entry, location)
+            )
 
-    @property
-    def humidity(self) -> int | None:
-        hum = _hourly_at_now(self.coordinator.data, "relative_humidity_2m")
-        return round(hum) if isinstance(hum, (int, float)) else None
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._update_device_name()
 
-    @property
-    def native_dew_point(self) -> float | None:
-        current_dp = self.coordinator.data.get("current", {}).get("dewpoint_2m")
-        if isinstance(current_dp, (int, float)):
-            return round(current_dp, 1)
-        val = _hourly_at_now(self.coordinator.data, "dewpoint_2m")
-        return round(val, 1) if isinstance(val, (int, float)) else None
-        val = self._hourly_value("dewpoint_2m")
-        return round(val, 1) if isinstance(val, (int, float)) else None
+    def _handle_coordinator_update(self) -> None:
+        self._update_device_name()
+        self.async_write_ha_state()
 
-    @property
-    def condition(self) -> str | None:
-        """Return the current weather condition."""
-        cw = self.coordinator.data.get("current_weather", {})
-        weather_code = cw.get("weathercode")
-        is_day = cw.get("is_day")
-        return _map_condition(weather_code, is_day) if weather_code is not None else None
-    
+    # -------------------------------------------------------------------------
+    # Helpers for forecasts and values
+    # -------------------------------------------------------------------------
     def _current_hour_index(self) -> int:
-        times = self.coordinator.data.get("hourly", {}).get("time") or []
+        times = (self.coordinator.data or {}).get("hourly", {}).get("time") or []
         if not isinstance(times, list):
             return 0
         now = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
-        for i, ts in enumerate(times):
+        for idx, ts in enumerate(times):
             dt = dt_util.parse_datetime(ts)
             if dt and dt_util.as_utc(dt) >= now:
-                return i
+                return idx
         return max(len(times) - 1, 0)
 
     def _hourly_value(self, key: str, idx: int | None = None) -> float | None:
-        arr = self.coordinator.data.get("hourly", {}).get(key)
+        hourly = (self.coordinator.data or {}).get("hourly", {})
+        arr = hourly.get(key)
         if not isinstance(arr, list) or not arr:
             return None
         if idx is None:
@@ -238,10 +208,11 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
         return None
 
     def _map_daily_forecast(self) -> list[dict[str, Any]]:
-        if not (daily := self.coordinator.data.get("daily")):
-            return []
-        
+        daily = (self.coordinator.data or {}).get("daily") or {}
         times = daily.get("time", [])
+        if not isinstance(times, list):
+            return []
+
         temp_max = daily.get("temperature_2m_max", [])
         temp_min = daily.get("temperature_2m_min", [])
         wcodes = daily.get("weathercode", [])
@@ -249,22 +220,94 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
         ws_max = daily.get("wind_speed_10m_max", [])
         wd_dom = daily.get("wind_direction_10m_dominant", [])
         pop = daily.get("precipitation_probability_max", [])
-        
-        out = []
-        for i, dt in enumerate(times):
+
+        result: list[dict[str, Any]] = []
+        for idx, dt in enumerate(times):
             forecast = {
                 ATTR_FORECAST_TIME: dt,
-                ATTR_FORECAST_TEMP: temp_max[i] if i < len(temp_max) else None,
-                ATTR_FORECAST_TEMP_LOW: temp_min[i] if i < len(temp_min) else None,
-                ATTR_FORECAST_CONDITION: _map_condition(wcodes[i]) if i < len(wcodes) else None,
-                ATTR_FORECAST_PRECIPITATION: precip_sum[i] if i < len(precip_sum) else None,
-                ATTR_FORECAST_WIND_SPEED: ws_max[i] if i < len(ws_max) else None,
-                ATTR_FORECAST_WIND_BEARING: wd_dom[i] if i < len(wd_dom) else None,
-                ATTR_FORECAST_PRECIPITATION_PROBABILITY: pop[i] if i < len(pop) else None,
+                ATTR_FORECAST_TEMP: temp_max[idx] if idx < len(temp_max) else None,
+                ATTR_FORECAST_TEMP_LOW: temp_min[idx] if idx < len(temp_min) else None,
+                ATTR_FORECAST_CONDITION: _map_condition(wcodes[idx])
+                if idx < len(wcodes)
+                else None,
+                ATTR_FORECAST_PRECIPITATION: precip_sum[idx]
+                if idx < len(precip_sum)
+                else None,
+                ATTR_FORECAST_WIND_SPEED: ws_max[idx] if idx < len(ws_max) else None,
+                ATTR_FORECAST_WIND_BEARING: wd_dom[idx] if idx < len(wd_dom) else None,
+                ATTR_FORECAST_PRECIPITATION_PROBABILITY: pop[idx]
+                if idx < len(pop)
+                else None,
             }
-            out.append(forecast)
-        return out
+            result.append(forecast)
+        return result
 
+    # -------------------------------------------------------------------------
+    # Entity properties
+    # -------------------------------------------------------------------------
+    @property
+    def name(self) -> str:
+        for candidate in (
+            (self.coordinator.data or {}).get("location_name"),
+            self._config_entry.options.get(CONF_AREA_NAME_OVERRIDE),
+            self._config_entry.title,
+        ):
+            if candidate:
+                return str(candidate)
+        return "Open-Meteo"
+
+    @property
+    def available(self) -> bool:
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def native_temperature(self) -> float | None:
+        current_weather = (self.coordinator.data or {}).get("current_weather", {})
+        temp = current_weather.get("temperature")
+        return round(temp, 1) if isinstance(temp, (int, float)) else None
+
+    @property
+    def native_pressure(self) -> float | None:
+        val = _hourly_at_now(self.coordinator.data or {}, "pressure_msl")
+        return round(val, 1) if isinstance(val, (int, float)) else None
+
+    @property
+    def native_wind_speed(self) -> float | None:
+        current_weather = (self.coordinator.data or {}).get("current_weather", {})
+        wind_speed = current_weather.get("windspeed")
+        return round(wind_speed, 1) if isinstance(wind_speed, (int, float)) else None
+
+    @property
+    def wind_bearing(self) -> float | None:
+        current_weather = (self.coordinator.data or {}).get("current_weather", {})
+        wind_dir = current_weather.get("winddirection")
+        return round(wind_dir, 1) if isinstance(wind_dir, (int, float)) else None
+
+    @property
+    def native_visibility(self) -> float | None:
+        visibility = _hourly_at_now(self.coordinator.data or {}, "visibility")
+        return round(visibility / 1000, 2) if isinstance(visibility, (int, float)) else None
+
+    @property
+    def humidity(self) -> int | None:
+        hum = _hourly_at_now(self.coordinator.data or {}, "relative_humidity_2m")
+        return round(hum) if isinstance(hum, (int, float)) else None
+
+    @property
+    def native_dew_point(self) -> float | None:
+        current = (self.coordinator.data or {}).get("current", {})
+        dew = current.get("dewpoint_2m")
+        if isinstance(dew, (int, float)):
+            return round(dew, 1)
+        val = _hourly_at_now(self.coordinator.data or {}, "dewpoint_2m")
+        return round(val, 1) if isinstance(val, (int, float)) else None
+
+    @property
+    def condition(self) -> str | None:
+        current_weather = (self.coordinator.data or {}).get("current_weather", {})
+        weather_code = current_weather.get("weathercode")
+        is_day = current_weather.get("is_day")
+        return _map_condition(weather_code, is_day)
 
     @property
     def forecast_daily(self) -> list[dict[str, Any]]:
@@ -274,17 +317,18 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
         return self.forecast_daily
 
     async def async_forecast_hourly(self) -> list[dict[str, Any]]:
-        hourly = self.coordinator.data.get("hourly") or {}
+        hourly = (self.coordinator.data or {}).get("hourly") or {}
         times = hourly.get("time") or []
         if not isinstance(times, list) or not times:
             _LOGGER.debug("Hourly forecast: 0 entries")
             return []
 
-        idx = self._current_hour_index()
-        end = min(len(times), idx + 72)
+        start_idx = self._current_hour_index()
+        end_idx = min(len(times), start_idx + 72)
+
         result: list[dict[str, Any]] = []
-        for i in range(idx, end):
-            ts = times[i]
+        for idx in range(start_idx, end_idx):
+            ts = times[idx]
             dt = dt_util.parse_datetime(ts)
             if not dt:
                 continue
@@ -303,17 +347,23 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
                 "cloud_coverage": "cloud_cover",
             }.items():
                 arr = hourly.get(src_key)
-                item[out_key] = arr[i] if isinstance(arr, list) and i < len(arr) else None
+                item[out_key] = arr[idx] if isinstance(arr, list) and idx < len(arr) else None
+
             wcodes = hourly.get("weathercode")
-            if isinstance(wcodes, list) and i < len(wcodes):
+            if isinstance(wcodes, list) and idx < len(wcodes):
                 is_day_arr = hourly.get("is_day", [])
-                is_day_val = is_day_arr[i] if isinstance(is_day_arr, list) and i < len(is_day_arr) else 1
-                item["condition"] = _map_condition(wcodes[i], is_day_val)
+                is_day_val = (
+                    is_day_arr[idx]
+                    if isinstance(is_day_arr, list) and idx < len(is_day_arr)
+                    else 1
+                )
+                item["condition"] = _map_condition(wcodes[idx], is_day_val)
             else:
                 item["condition"] = None
+
             result.append(item)
 
-        missing = sorted({k for f in result for k, v in f.items() if v is None})
+        missing = sorted({key for entry in result for key, value in entry.items() if value is None})
         if result:
             _LOGGER.debug(
                 "Hourly forecast: %d entries from %s to %s; missing fields: %s",
@@ -326,16 +376,9 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
             _LOGGER.debug("Hourly forecast: 0 entries")
         return result
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self.async_write_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        self.async_on_remove(self.coordinator.async_add_listener(self._handle_coordinator_update))
-
     @property
     def sunrise(self) -> datetime | None:
-        val = self.coordinator.data.get("daily", {}).get("sunrise", [None])[0]
+        val = (self.coordinator.data or {}).get("daily", {}).get("sunrise", [None])[0]
         if isinstance(val, str):
             dt = dt_util.parse_datetime(val)
         else:
@@ -349,7 +392,7 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
 
     @property
     def sunset(self) -> datetime | None:
-        val = self.coordinator.data.get("daily", {}).get("sunset", [None])[0]
+        val = (self.coordinator.data or {}).get("daily", {}).get("sunset", [None])[0]
         if isinstance(val, str):
             dt = dt_util.parse_datetime(val)
         else:
@@ -363,15 +406,16 @@ class OpenMeteoWeather(CoordinatorEntity, WeatherEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return additional state attributes."""
-        attrs = {
-            "location_name": self.coordinator.data.get("location_name"),
+        attrs: dict[str, Any] = {
+            "location_name": (self.coordinator.data or {}).get("location_name"),
             "mode": self._mode,
             "min_track_interval": self._min_track_interval,
-            "last_location_update": self.coordinator.data.get("last_location_update"),
+            "last_location_update": (self.coordinator.data or {}).get(
+                "last_location_update"
+            ),
             "provider": self._provider,
         }
-        dp = self.native_dew_point
-        if dp is not None:
-            attrs["dew_point"] = dp
+        dew = self.native_dew_point
+        if dew is not None:
+            attrs["dew_point"] = dew
         return attrs


### PR DESCRIPTION
## Summary
- reuse the coordinator reverse geocoder in the config flow and hide the place-name device option for static entries
- persist location names in the coordinator, updating the config entry title when a better label is available
- rework the weather entity to derive object ids and device names from the resolved place name while keeping metadata in sync

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c86ed83e54832d973503d4867a789a