### PR TITLE
Fix OpenMeteo config entry migration to update version safely

### DIFF
--- a/custom_components/openmeteo/__init__.py
+++ b/custom_components/openmeteo/__init__.py
@@ -166,6 +166,5 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if list_key in data:
                 data[list_key] = cleaned
 
-    entry.version = 3
-    hass.config_entries.async_update_entry(entry, data=data, options=options)
+    hass.config_entries.async_update_entry(entry, data=data, options=options, version=3)
     return True

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.openmeteo.__init__ import async_migrate_entry
+from custom_components.openmeteo.const import (
+    CONF_API_PROVIDER,
+    CONF_MIN_TRACK_INTERVAL,
+    CONF_MODE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_API_PROVIDER,
+    DEFAULT_MIN_TRACK_INTERVAL,
+    DEFAULT_UNITS,
+    DEFAULT_UPDATE_INTERVAL,
+    MODE_STATIC,
+)
+
+
+@pytest.mark.asyncio
+async def test_migration_uses_async_update_entry_for_version() -> None:
+    entry = SimpleNamespace(
+        data={"pv_legacy": 1},
+        options={"enabled_sensors": ["temperature", "pv_old"]},
+        version=2,
+    )
+
+    def _update_entry(target, **kwargs):
+        if "version" in kwargs:
+            target.version = kwargs["version"]
+
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_update_entry=MagicMock(side_effect=_update_entry))
+    )
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_called_once()
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["version"] == 3
+
+    migrated_data = kwargs["data"]
+    migrated_options = kwargs["options"]
+
+    assert migrated_data[CONF_MODE] == MODE_STATIC
+    assert migrated_data[CONF_MIN_TRACK_INTERVAL] == DEFAULT_MIN_TRACK_INTERVAL
+    assert migrated_data[CONF_UPDATE_INTERVAL] == DEFAULT_UPDATE_INTERVAL
+    assert migrated_data["units"] == DEFAULT_UNITS
+    assert migrated_data[CONF_API_PROVIDER] == DEFAULT_API_PROVIDER
+    assert "pv_legacy" not in migrated_data
+    assert migrated_options["enabled_sensors"] == ["temperature"]


### PR DESCRIPTION
### Motivation
- Prevent an `AttributeError` during config entry migration caused by directly assigning `entry.version`, and use the Home Assistant API to update entry version safely.

### Description
- Replace the invalid `entry.version = 3` assignment with `hass.config_entries.async_update_entry(entry, data=data, options=options, version=3)` in `custom_components/openmeteo/__init__.py`.
- Add `tests/test_migration.py` to assert `async_migrate_entry` calls `async_update_entry` with `version=3`, sets defaults, and cleans legacy `pv_` keys from data/options.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_migration.py` and it passed (1 passed).
- Ran `pytest -q` in this environment and it failed due to Home Assistant / pytest fixture and import mismatches that are unrelated to this change and outside the scope of the migration fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ace8af70c832d8deb39a34048b832)