### PR TITLE
Refine precipitation sensor label and reduce Air Quality warning spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Pogoda śledzi Twoją lokalizację w czasie rzeczywistym!
 
 ### 🌧️ Szczegóły opadów (nowe)
 
-Integracja zachowuje istniejący sensor **Opad (bieżąca godzina)** i dodatkowo udostępnia rozbicie na składniki opadu dla bieżącej godziny:
+Integracja zachowuje istniejący sensor **Opad łączny (bieżąca godzina)** i dodatkowo udostępnia rozbicie na składniki opadu dla bieżącej godziny:
 
 | Sensor | Opis | Jednostka |
 |--------|------|-----------|

--- a/custom_components/openmeteo/const.py
+++ b/custom_components/openmeteo/const.py
@@ -243,7 +243,7 @@ SENSOR_LABELS = {
     "wind_speed": {"pl": "Prędkość wiatru", "en": "Wind speed"},
     "wind_gust": {"pl": "Porywy wiatru", "en": "Wind gust"},
     "wind_bearing": {"pl": "Kierunek wiatru", "en": "Wind bearing"},
-    "precipitation_sum": {"pl": "Opad (bieżąca godzina)", "en": "Precipitation (this hour)"},
+    "precipitation_sum": {"pl": "Opad łączny (bieżąca godzina)", "en": "Total precipitation (this hour)"},
     "rain_current_hour": {"pl": "Deszcz (bieżąca godzina)", "en": "Rain (this hour)"},
     "snow_current_hour": {"pl": "Śnieg (bieżąca godzina)", "en": "Snow (this hour)"},
     "precipitation_daily_sum": {

--- a/custom_components/openmeteo/coordinator.py
+++ b/custom_components/openmeteo/coordinator.py
@@ -530,17 +530,12 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._last_data["last_location_update"] = last_loc_ts
             
             # Try to fetch air quality data (best-effort, non-critical)
-            try:
-                aq_data = await self._fetch_air_quality(latitude, longitude)
-                if aq_data and 'hourly' in aq_data:
-                    self._last_data["aq"] = aq_data
-                    _LOGGER.debug("Successfully fetched air quality data")
-                else:
-                    _LOGGER.warning("No air quality data in API response")
-            except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-                _LOGGER.warning("Network error fetching air quality data: %s", err)
-            except (KeyError, ValueError, TypeError) as err:
-                _LOGGER.warning("Invalid air quality data format: %s", err)
+            aq_data = await self._fetch_air_quality(latitude, longitude)
+            if aq_data and "hourly" in aq_data:
+                self._last_data["aq"] = aq_data
+                _LOGGER.debug("Successfully fetched air quality data")
+            elif aq_data is not None:
+                _LOGGER.debug("Air quality API response missing 'hourly' data")
 
             # Step 4: Persist last accepted coords / location name (with cooldown)
             try:
@@ -758,4 +753,7 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             _LOGGER.warning("Network error fetching air quality data: %s", err)
+            return None
+        except (KeyError, TypeError, ValueError) as err:
+            _LOGGER.debug("Invalid air quality data format: %s", err)
             return None

--- a/custom_components/openmeteo/sensor.py
+++ b/custom_components/openmeteo/sensor.py
@@ -180,7 +180,7 @@ SENSOR_TYPES: dict[str, OpenMeteoSensorDescription] = {
     "precipitation_sum": OpenMeteoSensorDescription(
         key="precipitation_sum",
         translation_key="precipitation_sum",
-        name="Opad (bieżąca godzina)",
+        name="Opad łączny (bieżąca godzina)",
         native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
         icon="mdi:cup-water",
         device_class=SensorDeviceClass.PRECIPITATION,

--- a/custom_components/openmeteo/translations/en.json
+++ b/custom_components/openmeteo/translations/en.json
@@ -176,7 +176,7 @@
       "name": "Precipitation probability"
     },
     "precipitation_sum": {
-      "name": "Precipitation (current hour)"
+      "name": "Total precipitation (current hour)"
     },
     "precipitation_daily_sum": {
       "name": "Daily precipitation sum"

--- a/custom_components/openmeteo/translations/pl.json
+++ b/custom_components/openmeteo/translations/pl.json
@@ -179,7 +179,7 @@
       "name": "Prawdopodobieństwo opadów"
     },
     "precipitation_sum": {
-      "name": "Opad (bieżąca godzina)"
+      "name": "Opad łączny (bieżąca godzina)"
     },
     "precipitation_daily_sum": {
       "name": "Suma opadów (dzienna)"

--- a/tests/test_coordinator_air_quality.py
+++ b/tests/test_coordinator_air_quality.py
@@ -7,11 +7,6 @@ import pytest
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry, async_test_home_assistant
 
-from custom_components.openmeteo import DOMAIN
-from custom_components.openmeteo.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE, MODE_STATIC
-from custom_components.openmeteo.coordinator import OpenMeteoDataUpdateCoordinator
-
-
 @pytest.fixture
 def expected_lingering_timers():
     """Allow lingering timers in lightweight coordinator tests."""
@@ -20,6 +15,15 @@ def expected_lingering_timers():
 
 @pytest.mark.asyncio
 async def test_aq_missing_hourly_does_not_log_warning(caplog: pytest.LogCaptureFixture):
+    from custom_components.openmeteo import DOMAIN
+    from custom_components.openmeteo.const import (
+        CONF_LATITUDE,
+        CONF_LONGITUDE,
+        CONF_MODE,
+        MODE_STATIC,
+    )
+    from custom_components.openmeteo.coordinator import OpenMeteoDataUpdateCoordinator
+
     with patch("homeassistant.util.dt.get_time_zone", return_value=dt_util.UTC):
         async with async_test_home_assistant() as hass:
             entry = MockConfigEntry(

--- a/tests/test_coordinator_air_quality.py
+++ b/tests/test_coordinator_air_quality.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+from pathlib import Path
+import sys
+
+import pytest
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry, async_test_home_assistant
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from custom_components.openmeteo import DOMAIN
+from custom_components.openmeteo.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE, MODE_STATIC
+from custom_components.openmeteo.coordinator import OpenMeteoDataUpdateCoordinator
+
+
+@pytest.fixture
+def expected_lingering_timers():
+    """Allow lingering timers in lightweight coordinator tests."""
+    return True
+
+
+@pytest.mark.asyncio
+async def test_aq_missing_hourly_does_not_log_warning(
+    caplog: pytest.LogCaptureFixture, event_loop
+):
+    with patch("homeassistant.util.dt.get_time_zone", return_value=dt_util.UTC):
+        hass = await async_test_home_assistant(event_loop)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_MODE: MODE_STATIC, CONF_LATITUDE: 50.0, CONF_LONGITUDE: 20.0},
+            options={},
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = OpenMeteoDataUpdateCoordinator(hass, entry)
+
+        with patch.object(
+            coordinator, "_fetch_weather_data", AsyncMock(return_value={})
+        ), patch.object(
+            coordinator, "_fetch_air_quality", AsyncMock(return_value={"foo": "bar"})
+        ), patch.object(
+            coordinator, "_update_location_name", AsyncMock(return_value="Test place")
+        ), patch.object(
+            coordinator, "_should_update_entry_title", return_value=False
+        ):
+            with caplog.at_level(logging.WARNING):
+                result = await coordinator._async_update_data()
+
+        assert "aq" not in result
+        assert not any("air quality" in record.getMessage().lower() for record in caplog.records)

--- a/tests/test_coordinator_air_quality.py
+++ b/tests/test_coordinator_air_quality.py
@@ -2,15 +2,10 @@ from __future__ import annotations
 
 import logging
 from unittest.mock import AsyncMock, patch
-from pathlib import Path
-import sys
 
 import pytest
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry, async_test_home_assistant
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from custom_components.openmeteo import DOMAIN
 from custom_components.openmeteo.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE, MODE_STATIC
@@ -24,31 +19,29 @@ def expected_lingering_timers():
 
 
 @pytest.mark.asyncio
-async def test_aq_missing_hourly_does_not_log_warning(
-    caplog: pytest.LogCaptureFixture, event_loop
-):
+async def test_aq_missing_hourly_does_not_log_warning(caplog: pytest.LogCaptureFixture):
     with patch("homeassistant.util.dt.get_time_zone", return_value=dt_util.UTC):
-        hass = await async_test_home_assistant(event_loop)
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_MODE: MODE_STATIC, CONF_LATITUDE: 50.0, CONF_LONGITUDE: 20.0},
-            options={},
-        )
-        entry.add_to_hass(hass)
+        async with async_test_home_assistant() as hass:
+            entry = MockConfigEntry(
+                domain=DOMAIN,
+                data={CONF_MODE: MODE_STATIC, CONF_LATITUDE: 50.0, CONF_LONGITUDE: 20.0},
+                options={},
+            )
+            entry.add_to_hass(hass)
 
-        coordinator = OpenMeteoDataUpdateCoordinator(hass, entry)
+            coordinator = OpenMeteoDataUpdateCoordinator(hass, entry)
 
-        with patch.object(
-            coordinator, "_fetch_weather_data", AsyncMock(return_value={})
-        ), patch.object(
-            coordinator, "_fetch_air_quality", AsyncMock(return_value={"foo": "bar"})
-        ), patch.object(
-            coordinator, "_update_location_name", AsyncMock(return_value="Test place")
-        ), patch.object(
-            coordinator, "_should_update_entry_title", return_value=False
-        ):
-            with caplog.at_level(logging.WARNING):
-                result = await coordinator._async_update_data()
+            with patch.object(
+                coordinator, "_fetch_weather_data", AsyncMock(return_value={})
+            ), patch.object(
+                coordinator, "_fetch_air_quality", AsyncMock(return_value={"foo": "bar"})
+            ), patch.object(
+                coordinator, "_update_location_name", AsyncMock(return_value="Test place")
+            ), patch.object(
+                coordinator, "_should_update_entry_title", return_value=False
+            ):
+                with caplog.at_level(logging.WARNING):
+                    result = await coordinator._async_update_data()
 
-        assert "aq" not in result
-        assert not any("air quality" in record.getMessage().lower() for record in caplog.records)
+            assert "aq" not in result
+            assert not any("air quality" in record.getMessage().lower() for record in caplog.records)

--- a/tests/test_precip_split_sensors.py
+++ b/tests/test_precip_split_sensors.py
@@ -16,6 +16,12 @@ def test_precipitation_split_current_hour_values():
     assert SENSOR_TYPES["snow_current_hour"].value_fn(data) == 1.2
 
 
+def test_precipitation_sum_display_name():
+    from custom_components.openmeteo.sensor import SENSOR_TYPES
+
+    assert SENSOR_TYPES["precipitation_sum"].name == "Opad łączny (bieżąca godzina)"
+
+
 def test_no_legacy_generation_sensors_present():
     from custom_components.openmeteo.sensor import SENSOR_TYPES
 


### PR DESCRIPTION
### Motivation
- Make a small UX-only rename of the combined precipitation sensor so it reads clearer for users while preserving existing keys and semantics.
- Reduce duplicated / noisy warning logs coming from the optional Air Quality (AQ) fetch so best-effort AQ failures do not spam warnings while real network/API failures remain visible.

### Description
- Renamed the display name for the precipitation aggregate sensor: changed `precipitation_sum` display to "Opad łączny (bieżąca godzina)" in the sensor description and made labels/translations consistent in the constants and translation files (Polish/English) and README; the underlying key `precipitation_sum` and its calculation remain unchanged (no semantic changes to values).
- Toned down AQ warning noise in `coordinator.py` by treating a missing/partial AQ payload as non-critical: `_async_update_data()` now logs missing `hourly` as `debug` instead of `warning`, and `_fetch_air_quality()` keeps network/API errors as `warning` while parsing/format errors are logged at `debug` and return `None`.
- Added a focused unit test `tests/test_coordinator_air_quality.py` that verifies missing `hourly` in AQ response does not emit warnings, and added `test_precipitation_sum_display_name` to `tests/test_precip_split_sensors.py` to cover the new display name.
- Files changed: `custom_components/openmeteo/sensor.py`, `custom_components/openmeteo/const.py`, `custom_components/openmeteo/coordinator.py`, `custom_components/openmeteo/translations/pl.json`, `custom_components/openmeteo/translations/en.json`, `README.md`, `tests/test_precip_split_sensors.py`, and `tests/test_coordinator_air_quality.py`.
- Compatibility: no changes to `entity_id`, `unique_id`, `object_id`, or the `precipitation_sum` key/semantics; existing automations/blueprints remain compatible.

### Testing
- Ran `pytest -q tests/test_coordinator_air_quality.py` and it passed (new AQ test confirms no warning on missing `hourly`).
- Ran `pytest -q tests/test_precip_split_sensors.py tests/test_coordinator_air_quality.py` which initially failed in the local environment due to an existing Home Assistant package/import mismatch unrelated to these changes; the added sensor name assertion and AQ test are targeted and should pass in CI with a matching HA test runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bc59ccbc832d9657bb9d109dd89e)