### PR TITLE
Stabilize OpenMeteo runtime hass.data access and test harness

### DIFF
--- a/custom_components/openmeteo/__init__.py
+++ b/custom_components/openmeteo/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_LONGITUDE,
 )
 from .coordinator import OpenMeteoDataUpdateCoordinator
+from .runtime import get_entry_coordinator
 
 
 # ---- Test-patched symbol (must exist at module level) ----
@@ -106,16 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload when options are updated."""
-    stored = hass.data.get(DOMAIN)
-    coordinator: OpenMeteoDataUpdateCoordinator | None = None
-    if isinstance(stored, dict):
-        maybe = stored.get(entry.entry_id)
-        if isinstance(maybe, OpenMeteoDataUpdateCoordinator):
-            coordinator = maybe
-        elif isinstance(maybe, dict):
-            potential = maybe.get("coordinator")
-            if isinstance(potential, OpenMeteoDataUpdateCoordinator):
-                coordinator = potential
+    coordinator = get_entry_coordinator(hass, entry.entry_id)
     if coordinator and coordinator.consume_suppress_reload():
         return
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/openmeteo/runtime.py
+++ b/custom_components/openmeteo/runtime.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime access helpers for Open-Meteo hass.data state."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+EntryStore = dict[str, Any]
+
+
+def _get_domain_store(hass: HomeAssistant) -> dict[str, Any]:
+    """Return Open-Meteo domain store as a dict."""
+    store = hass.data.get(DOMAIN)
+    return store if isinstance(store, dict) else {}
+
+
+def get_entry_coordinator(hass: HomeAssistant, entry_id: str) -> Any | None:
+    """Return coordinator for an entry, supporting legacy wrapped storage shape."""
+    domain_store = _get_domain_store(hass)
+    value = domain_store.get(entry_id)
+    if isinstance(value, dict):
+        return value.get("coordinator")
+    return value
+
+
+def get_entry_runtime_store(hass: HomeAssistant, entry_id: str) -> EntryStore | None:
+    """Return runtime metadata store for an entry or None when unavailable."""
+    entries = _get_domain_store(hass).get("entries")
+    if not isinstance(entries, dict):
+        return None
+    store = entries.get(entry_id)
+    return store if isinstance(store, dict) else None
+
+
+def get_or_create_entry_runtime_store(hass: HomeAssistant, entry_id: str) -> EntryStore:
+    """Return runtime metadata store for an entry and create it when missing."""
+    domain_store = hass.data.setdefault(DOMAIN, {})
+    entries = domain_store.setdefault("entries", {})
+    store = entries.setdefault(entry_id, {})
+    return store

--- a/custom_components/openmeteo/sensor.py
+++ b/custom_components/openmeteo/sensor.py
@@ -39,6 +39,11 @@ from .helpers import (
     extra_attrs as _extra_attrs,
     aq_hour_value as _aq_hour_value,
 )
+from .runtime import (
+    get_entry_coordinator,
+    get_entry_runtime_store,
+    get_or_create_entry_runtime_store,
+)
 import logging
 
 from .coordinator import OpenMeteoDataUpdateCoordinator
@@ -452,11 +457,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Open-Meteo sensor based on a config entry."""
-    # Koordynator może być zapisany bezpośrednio lub pod kluczem "coordinator"
-    stored = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator: OpenMeteoDataUpdateCoordinator = (
-        stored.get("coordinator") if isinstance(stored, dict) else stored
-    )
+    coordinator: OpenMeteoDataUpdateCoordinator = get_entry_coordinator(hass, config_entry.entry_id)
 
     def _as_list(source: Mapping[str, Any] | None, key: str) -> list[str] | None:
         if not source:
@@ -585,11 +586,7 @@ class OpenMeteoSensor(CoordinatorEntity[OpenMeteoDataUpdateCoordinator], SensorE
     def extra_state_attributes(self):
         attrs = _extra_attrs(self.coordinator.data or {})
         try:
-            store = (
-                self.hass.data.get(DOMAIN, {})
-                .get("entries", {})
-                .get(self._config_entry.entry_id, {})
-            )
+            store = get_entry_runtime_store(self.hass, self._config_entry.entry_id) or {}
             src = store.get("src")
             if src:
                 attrs["source"] = src
@@ -604,20 +601,12 @@ class OpenMeteoSensor(CoordinatorEntity[OpenMeteoDataUpdateCoordinator], SensorE
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
-        store = (
-            self.hass.data.get(DOMAIN, {})
-            .get("entries", {})
-            .setdefault(self._config_entry.entry_id, {})
-        )
+        store = get_or_create_entry_runtime_store(self.hass, self._config_entry.entry_id)
         store.setdefault("entities", []).append(self)
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        store = (
-            self.hass.data.get(DOMAIN, {})
-            .get("entries", {})
-            .get(self._config_entry.entry_id)
-        )
+        store = get_entry_runtime_store(self.hass, self._config_entry.entry_id)
         if store and self in store.get("entities", []):
             store["entities"].remove(self)
         await super().async_will_remove_from_hass()
@@ -680,19 +669,11 @@ class OpenMeteoUvIndexSensor(CoordinatorEntity[OpenMeteoDataUpdateCoordinator], 
             async_dispatcher_connect(self.hass, signal, self._handle_place_update)
         )
         self._handle_place_update()
-        store = (
-            self.hass.data.setdefault(DOMAIN, {})
-            .setdefault("entries", {})
-            .setdefault(self._config_entry.entry_id, {})
-        )
+        store = get_or_create_entry_runtime_store(self.hass, self._config_entry.entry_id)
         store.setdefault("entities", []).append(self)
 
     async def async_will_remove_from_hass(self) -> None:
-        store = (
-            self.hass.data.get(DOMAIN, {})
-            .get("entries", {})
-            .get(self._config_entry.entry_id)
-        )
+        store = get_entry_runtime_store(self.hass, self._config_entry.entry_id)
         if store and self in store.get("entities", []):
             store["entities"].remove(self)
         await super().async_will_remove_from_hass()
@@ -777,20 +758,12 @@ class OpenMeteoAqSensor(CoordinatorEntity[OpenMeteoDataUpdateCoordinator], Senso
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
-        store = (
-            self.hass.data.get(DOMAIN, {})
-            .get("entries", {})
-            .setdefault(self._config_entry.entry_id, {})
-        )
+        store = get_or_create_entry_runtime_store(self.hass, self._config_entry.entry_id)
         store.setdefault("entities", []).append(self)
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        store = (
-            self.hass.data.get(DOMAIN, {})
-            .get("entries", {})
-            .get(self._config_entry.entry_id)
-        )
+        store = get_entry_runtime_store(self.hass, self._config_entry.entry_id)
         if store and self in store.get("entities", []):
             store["entities"].remove(self)
         await super().async_will_remove_from_hass()

--- a/custom_components/openmeteo/weather.py
+++ b/custom_components/openmeteo/weather.py
@@ -56,6 +56,7 @@ from .helpers import (
     hourly_index_at_now as _hourly_index_at_now,
     maybe_update_device_name,
 )
+from .runtime import get_entry_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,7 +109,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Open-Meteo weather entity from a config entry."""
 
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = get_entry_coordinator(hass, config_entry.entry_id)
 
     # Jednorazowa migracja istniejącej encji pogody do stabilnego schematu
     ent_reg = er.async_get(hass)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+pytest_plugins = "pytest_homeassistant_custom_component"

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.openmeteo.const import DOMAIN
+from custom_components.openmeteo.runtime import (
+    get_entry_coordinator,
+    get_entry_runtime_store,
+    get_or_create_entry_runtime_store,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_entry_coordinator_supports_canonical_and_wrapped_shape() -> None:
+    hass = SimpleNamespace(data={DOMAIN: {"entry_a": "coord_a", "entry_b": {"coordinator": "coord_b"}}})
+
+    assert get_entry_coordinator(hass, "entry_a") == "coord_a"
+    assert get_entry_coordinator(hass, "entry_b") == "coord_b"
+
+
+@pytest.mark.asyncio
+async def test_runtime_store_create_and_read_consistent() -> None:
+    hass = SimpleNamespace(data={})
+
+    store = get_or_create_entry_runtime_store(hass, "entry_a")
+    store["src"] = "forecast"
+
+    resolved = get_entry_runtime_store(hass, "entry_a")
+
+    assert resolved is store
+    assert resolved == {"src": "forecast"}
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_entry_uses_runtime_coordinator_helper() -> None:
+    text = Path("custom_components/openmeteo/sensor.py").read_text(encoding="utf-8")
+    assert "get_entry_coordinator(hass, config_entry.entry_id)" in text
+    assert 'stored.get("coordinator") if isinstance(stored, dict) else stored' not in text

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
+from custom_components.openmeteo import async_update_entry
 from custom_components.openmeteo.const import DOMAIN
 from custom_components.openmeteo.runtime import (
     get_entry_coordinator,
@@ -35,7 +36,14 @@ async def test_runtime_store_create_and_read_consistent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sensor_setup_entry_uses_runtime_coordinator_helper() -> None:
-    text = Path("custom_components/openmeteo/sensor.py").read_text(encoding="utf-8")
-    assert "get_entry_coordinator(hass, config_entry.entry_id)" in text
-    assert 'stored.get("coordinator") if isinstance(stored, dict) else stored' not in text
+async def test_async_update_entry_uses_wrapped_coordinator_without_reload() -> None:
+    coordinator = SimpleNamespace(consume_suppress_reload=lambda: True)
+    entry = SimpleNamespace(entry_id="entry_wrapped")
+    hass = SimpleNamespace(
+        data={DOMAIN: {"entry_wrapped": {"coordinator": coordinator}}},
+        config_entries=SimpleNamespace(async_reload=AsyncMock()),
+    )
+
+    await async_update_entry(hass, entry)
+
+    hass.config_entries.async_reload.assert_not_called()


### PR DESCRIPTION
### Motivation
- Ustabilizować i scentralizować dostęp do runtime state integracji przechowywanego w `hass.data`, ukrywając legacy shape w jednym miejscu bez zmiany zachowania integracji.
- Ograniczyć kruchość testów przez drobne poprawki harnessu tak, aby szybkie, małe regresyjne testy były przewidywalne.

### Description
- Dodano nowy helper `custom_components.openmeteo.runtime` z funkcjami `get_entry_coordinator`, `get_entry_runtime_store` i `get_or_create_entry_runtime_store` jako canonical access layer dla `hass.data`.
- Zastąpiono ad-hoc odczyty `hass.data[DOMAIN][entry_id]` i wielokrotne lokalne rozgałęzienia kształtu w `__init__.py`, `sensor.py` i `weather.py` wywołaniami helperów (`get_entry_coordinator` / `get_entry_runtime_store` / `get_or_create_entry_runtime_store`).
- Zachowano kompatybilność z legacy shape (bezpośredni coordinator lub `{"coordinator": ...}`) i nie zmieniono semantyki encji, `unique_id`, `entity_id`, ani logiki fetchowania danych.
- Dodano testowy plik `tests/test_runtime_state.py` z małymi testami regresyjnymi oraz `tests/conftest.py` dla stabilniejszego test harnessu.

### Testing
- Uruchomiono `pytest -q tests/test_runtime_state.py tests/test_migration.py` i wszystkie testy zakończyły się pomyślnie (`4 passed`).
- Poprzednie nieistotne problemy z importami w czasie developmentu zostały naprawione przez dodanie `tests/conftest.py` i iteracyjne poprawki; końcowy zestaw testów użyty do walidacji przeszedł pozytywnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cf42b170832d900faebbfb0354f9)