### PR TITLE
Fix V2 config flow translations and tracking labels

### DIFF
--- a/custom_components/openmeteo/config_flow.py
+++ b/custom_components/openmeteo/config_flow.py
@@ -57,9 +57,9 @@ def _label_options(hass: HomeAssistant, keys: list[str]) -> list[dict[str, str]]
 def _mode_selector(hass: HomeAssistant) -> selector.SelectSelector:
     language = (hass.config.language or "en").split("-", 1)[0].lower()
     if language == "pl":
-        labels = {MODE_STATIC: "Stała lokalizacja", MODE_TRACK: "Śledź encję"}
+        labels = {MODE_STATIC: "Stała lokalizacja", MODE_TRACK: "Śledź lokalizację"}
     else:
-        labels = {MODE_STATIC: "Static location", MODE_TRACK: "Track an entity"}
+        labels = {MODE_STATIC: "Static location", MODE_TRACK: "Track location"}
     return selector.SelectSelector(
         selector.SelectSelectorConfig(
             options=[{"value": value, "label": label} for value, label in labels.items()],

--- a/custom_components/openmeteo/strings.json
+++ b/custom_components/openmeteo/strings.json
@@ -1,0 +1,71 @@
+{
+  "title": "Open-Meteo",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Open-Meteo",
+        "description": "Choose the location source. Tracking follows the selected entity without changing Open-Meteo entity identity.",
+        "data": {"mode": "Location mode"}
+      },
+      "details": {
+        "title": "Weather source setup",
+        "description": "Configure location, update frequency and sensors.",
+        "data": {
+          "location": "Location",
+          "entity_id": "Location source",
+          "min_track_interval": "Minimum position update interval (min)",
+          "update_interval_min": "Weather refresh interval (min)",
+          "area_name_override": "Display name override (optional)",
+          "reverse_geocode_cooldown_min": "Place-name refresh interval (min)",
+          "enabled_weather_sensors": "Weather sensors",
+          "enabled_aq_sensors": "Air quality sensors"
+        },
+        "data_description": {
+          "entity_id": "Select a person or device tracker that provides GPS coordinates.",
+          "min_track_interval": "Small movements are grouped. Large location changes are accepted immediately.",
+          "area_name_override": "Leave empty to display the current place automatically.",
+          "reverse_geocode_cooldown_min": "Limits reverse-geocoding calls for small position changes."
+        }
+      }
+    },
+    "error": {
+      "required": "This field is required",
+      "missing_entity": "Select a location source",
+      "invalid_entity": "The selected entity does not expose GPS coordinates"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Open-Meteo options",
+        "description": "Choose the location mode.",
+        "data": {"mode": "Location mode"}
+      },
+      "details": {
+        "title": "Weather source options",
+        "description": "Changing these settings does not change the stable identity of existing entities.",
+        "data": {
+          "location": "Location",
+          "entity_id": "Location source",
+          "min_track_interval": "Minimum position update interval (min)",
+          "update_interval_min": "Weather refresh interval (min)",
+          "area_name_override": "Display name override (optional)",
+          "reverse_geocode_cooldown_min": "Place-name refresh interval (min)",
+          "enabled_weather_sensors": "Weather sensors",
+          "enabled_aq_sensors": "Air quality sensors"
+        },
+        "data_description": {
+          "entity_id": "Select a person or device tracker that provides GPS coordinates.",
+          "min_track_interval": "Small movements are grouped. Large location changes are accepted immediately.",
+          "area_name_override": "Leave empty to display the current place automatically.",
+          "reverse_geocode_cooldown_min": "Limits reverse-geocoding calls for small position changes."
+        }
+      }
+    },
+    "error": {
+      "required": "This field is required",
+      "missing_entity": "Select a location source",
+      "invalid_entity": "The selected entity does not expose GPS coordinates"
+    }
+  }
+}

--- a/custom_components/openmeteo/translations/en.json
+++ b/custom_components/openmeteo/translations/en.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Open-Meteo",
-        "description": "Choose the location source. Tracking follows the selected entity without changing Open-Meteo entity identity.",
+        "description": "Choose how the weather location is determined. Location tracking follows the selected person or device without changing Open-Meteo entity identity.",
         "data": {"mode": "Location mode"}
       },
       "details": {
@@ -12,33 +12,33 @@
         "description": "Configure location, update frequency and sensors.",
         "data": {
           "location": "Location",
-          "entity_id": "Location entity",
-          "min_track_interval": "Minimum interval for small position changes (min)",
-          "update_interval_min": "Weather update interval (min)",
-          "area_name_override": "Fixed source name (optional)",
-          "reverse_geocode_cooldown_min": "Minimum place-name refresh interval (min)",
+          "entity_id": "Location source",
+          "min_track_interval": "Minimum position update interval (min)",
+          "update_interval_min": "Weather refresh interval (min)",
+          "area_name_override": "Display name override (optional)",
+          "reverse_geocode_cooldown_min": "Place-name refresh interval (min)",
           "enabled_weather_sensors": "Weather sensors",
           "enabled_aq_sensors": "Air quality sensors"
         },
         "data_description": {
-          "entity_id": "Select a person or device_tracker exposing latitude and longitude.",
-          "min_track_interval": "Small movements are grouped. Large location changes are accepted immediately.",
-          "area_name_override": "Leave empty to let the entry and device display the current place.",
-          "reverse_geocode_cooldown_min": "Limits reverse-geocoding calls for small position changes."
+          "entity_id": "Select a person or device that provides GPS coordinates.",
+          "min_track_interval": "Small position changes are grouped. Large location changes are accepted immediately.",
+          "area_name_override": "Leave empty to display the current place automatically.",
+          "reverse_geocode_cooldown_min": "Limits how often the place name is resolved for small position changes."
         }
       }
     },
     "error": {
       "required": "This field is required",
-      "missing_entity": "Select a location entity",
-      "invalid_entity": "The selected entity does not expose GPS coordinates"
+      "missing_entity": "Select a location source",
+      "invalid_entity": "The selected person or device does not expose GPS coordinates"
     }
   },
   "options": {
     "step": {
       "init": {
         "title": "Open-Meteo options",
-        "description": "Choose the location mode.",
+        "description": "Choose how the location is determined.",
         "data": {"mode": "Location mode"}
       },
       "details": {
@@ -46,26 +46,26 @@
         "description": "Changing these settings does not change the stable identity of existing entities.",
         "data": {
           "location": "Location",
-          "entity_id": "Location entity",
-          "min_track_interval": "Minimum interval for small position changes (min)",
-          "update_interval_min": "Weather update interval (min)",
-          "area_name_override": "Fixed source name (optional)",
-          "reverse_geocode_cooldown_min": "Minimum place-name refresh interval (min)",
+          "entity_id": "Location source",
+          "min_track_interval": "Minimum position update interval (min)",
+          "update_interval_min": "Weather refresh interval (min)",
+          "area_name_override": "Display name override (optional)",
+          "reverse_geocode_cooldown_min": "Place-name refresh interval (min)",
           "enabled_weather_sensors": "Weather sensors",
           "enabled_aq_sensors": "Air quality sensors"
         },
         "data_description": {
-          "entity_id": "Select a person or device_tracker exposing latitude and longitude.",
-          "min_track_interval": "Small movements are grouped. Large location changes are accepted immediately.",
-          "area_name_override": "Leave empty to let the entry and device display the current place.",
-          "reverse_geocode_cooldown_min": "Limits reverse-geocoding calls for small position changes."
+          "entity_id": "Select a person or device that provides GPS coordinates.",
+          "min_track_interval": "Small position changes are grouped. Large location changes are accepted immediately.",
+          "area_name_override": "Leave empty to display the current place automatically.",
+          "reverse_geocode_cooldown_min": "Limits how often the place name is resolved for small position changes."
         }
       }
     },
     "error": {
       "required": "This field is required",
-      "missing_entity": "Select a location entity",
-      "invalid_entity": "The selected entity does not expose GPS coordinates"
+      "missing_entity": "Select a location source",
+      "invalid_entity": "The selected person or device does not expose GPS coordinates"
     }
   }
 }

--- a/custom_components/openmeteo/translations/pl.json
+++ b/custom_components/openmeteo/translations/pl.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "title": "Open-Meteo",
-        "description": "Wybierz źródło lokalizacji. Tryb śledzenia aktualizuje pogodę według pozycji wybranej encji, ale nie zmienia tożsamości encji Open-Meteo.",
+        "description": "Wybierz sposób określania lokalizacji dla pogody. Śledzenie lokalizacji korzysta z pozycji wybranej osoby lub urządzenia, ale nie zmienia tożsamości encji Open-Meteo.",
         "data": {"mode": "Tryb lokalizacji"}
       },
       "details": {
@@ -12,33 +12,33 @@
         "description": "Ustaw lokalizację, częstotliwość aktualizacji oraz sensory.",
         "data": {
           "location": "Lokalizacja",
-          "entity_id": "Encja lokalizacji",
-          "min_track_interval": "Minimalny odstęp małych zmian pozycji (min)",
-          "update_interval_min": "Interwał odświeżania pogody (min)",
-          "area_name_override": "Stała nazwa źródła (opcjonalnie)",
-          "reverse_geocode_cooldown_min": "Minimalny odstęp odświeżania nazwy miejsca (min)",
+          "entity_id": "Źródło lokalizacji",
+          "min_track_interval": "Minimalny odstęp aktualizacji pozycji (min)",
+          "update_interval_min": "Odświeżanie pogody (min)",
+          "area_name_override": "Nazwa wyświetlana (opcjonalnie)",
+          "reverse_geocode_cooldown_min": "Odświeżanie nazwy miejsca (min)",
           "enabled_weather_sensors": "Sensory pogody",
           "enabled_aq_sensors": "Sensory jakości powietrza"
         },
         "data_description": {
-          "entity_id": "Wybierz person lub device_tracker z atrybutami latitude i longitude.",
-          "min_track_interval": "Małe ruchy są grupowane. Duża zmiana lokalizacji jest przyjmowana natychmiast.",
-          "area_name_override": "Pozostaw puste, aby nazwa wpisu i urządzenia pokazywała aktualną miejscowość.",
-          "reverse_geocode_cooldown_min": "Ogranicza wywołania geokodowania przy małych zmianach pozycji."
+          "entity_id": "Wybierz osobę lub urządzenie, które udostępnia współrzędne GPS.",
+          "min_track_interval": "Małe zmiany pozycji są grupowane. Duża zmiana lokalizacji jest przyjmowana natychmiast.",
+          "area_name_override": "Pozostaw puste, aby automatycznie wyświetlać aktualną miejscowość.",
+          "reverse_geocode_cooldown_min": "Ogranicza częstotliwość ustalania nazwy miejscowości przy małych zmianach pozycji."
         }
       }
     },
     "error": {
       "required": "To pole jest wymagane",
-      "missing_entity": "Wybierz encję lokalizacji",
-      "invalid_entity": "Wybrana encja nie udostępnia współrzędnych GPS"
+      "missing_entity": "Wybierz źródło lokalizacji",
+      "invalid_entity": "Wybrana osoba lub urządzenie nie udostępnia współrzędnych GPS"
     }
   },
   "options": {
     "step": {
       "init": {
         "title": "Opcje Open-Meteo",
-        "description": "Wybierz tryb lokalizacji.",
+        "description": "Wybierz sposób określania lokalizacji.",
         "data": {"mode": "Tryb lokalizacji"}
       },
       "details": {
@@ -46,26 +46,26 @@
         "description": "Zmiana tych ustawień nie zmienia stałej tożsamości istniejących encji.",
         "data": {
           "location": "Lokalizacja",
-          "entity_id": "Encja lokalizacji",
-          "min_track_interval": "Minimalny odstęp małych zmian pozycji (min)",
-          "update_interval_min": "Interwał odświeżania pogody (min)",
-          "area_name_override": "Stała nazwa źródła (opcjonalnie)",
-          "reverse_geocode_cooldown_min": "Minimalny odstęp odświeżania nazwy miejsca (min)",
+          "entity_id": "Źródło lokalizacji",
+          "min_track_interval": "Minimalny odstęp aktualizacji pozycji (min)",
+          "update_interval_min": "Odświeżanie pogody (min)",
+          "area_name_override": "Nazwa wyświetlana (opcjonalnie)",
+          "reverse_geocode_cooldown_min": "Odświeżanie nazwy miejsca (min)",
           "enabled_weather_sensors": "Sensory pogody",
           "enabled_aq_sensors": "Sensory jakości powietrza"
         },
         "data_description": {
-          "entity_id": "Wybierz person lub device_tracker z atrybutami latitude i longitude.",
-          "min_track_interval": "Małe ruchy są grupowane. Duża zmiana lokalizacji jest przyjmowana natychmiast.",
-          "area_name_override": "Pozostaw puste, aby nazwa wpisu i urządzenia pokazywała aktualną miejscowość.",
-          "reverse_geocode_cooldown_min": "Ogranicza wywołania geokodowania przy małych zmianach pozycji."
+          "entity_id": "Wybierz osobę lub urządzenie, które udostępnia współrzędne GPS.",
+          "min_track_interval": "Małe zmiany pozycji są grupowane. Duża zmiana lokalizacji jest przyjmowana natychmiast.",
+          "area_name_override": "Pozostaw puste, aby automatycznie wyświetlać aktualną miejscowość.",
+          "reverse_geocode_cooldown_min": "Ogranicza częstotliwość ustalania nazwy miejscowości przy małych zmianach pozycji."
         }
       }
     },
     "error": {
       "required": "To pole jest wymagane",
-      "missing_entity": "Wybierz encję lokalizacji",
-      "invalid_entity": "Wybrana encja nie udostępnia współrzędnych GPS"
+      "missing_entity": "Wybierz źródło lokalizacji",
+      "invalid_entity": "Wybrana osoba lub urządzenie nie udostępnia współrzędnych GPS"
     }
   }
 }

--- a/tests/test_translations_v2.py
+++ b/tests/test_translations_v2.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+COMPONENT_DIR = Path("custom_components/openmeteo")
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def test_base_strings_define_config_and_options_form_labels() -> None:
+    strings = _load_json(COMPONENT_DIR / "strings.json")
+
+    config_data = strings["config"]["step"]["details"]["data"]
+    options_data = strings["options"]["step"]["details"]["data"]
+
+    expected = {
+        "location",
+        "entity_id",
+        "min_track_interval",
+        "update_interval_min",
+        "area_name_override",
+        "reverse_geocode_cooldown_min",
+        "enabled_weather_sensors",
+        "enabled_aq_sensors",
+    }
+    assert expected <= set(config_data)
+    assert expected <= set(options_data)
+
+
+def test_polish_translation_covers_v2_form_labels() -> None:
+    translation = _load_json(COMPONENT_DIR / "translations/pl.json")
+    details = translation["config"]["step"]["details"]
+
+    assert details["data"]["entity_id"] == "Źródło lokalizacji"
+    assert details["data"]["update_interval_min"] == "Odświeżanie pogody (min)"
+    assert "GPS" in details["data_description"]["entity_id"]


### PR DESCRIPTION
## Problem
Live HA 2026.8 testing showed that the V2 config/options flow displayed raw schema keys such as `entity_id`, `min_track_interval`, `update_interval_min` and `reverse_geocode_cooldown_min`. The integration had `translations/en.json` and `translations/pl.json`, but no base `strings.json`.

The Polish tracking mode label `Śledź encję` was also too implementation-oriented for normal users.

## Changes
- add the missing `custom_components/openmeteo/strings.json` base translation resource
- rename Polish tracking mode to `Śledź lokalizację`
- rename the tracking entity field to `Źródło lokalizacji`
- simplify Polish labels/descriptions for update intervals, display-name override and reverse geocoding
- align English translations with the same wording
- add a regression test requiring the V2 config/options form translation keys

## Scope
UI/translation hotfix only. Backend config keys and V2 runtime identity remain unchanged.

Live retest on Home Assistant is required after CI passes.